### PR TITLE
Resolver

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,9 +54,6 @@ func init() {
 	DefaultUserAgent = fmt.Sprintf("%s (github.com/segmentio/consul-go)", filepath.Base(os.Args[0]))
 }
 
-// An ID is a general purpose unique identifier.
-type ID string
-
 // A Client exposes an API for communicating with a consul agent.
 //
 // The properties of a client are only read by its method, it is therefore safe

--- a/client.go
+++ b/client.go
@@ -34,8 +34,7 @@ var (
 	// the loopback interface.
 	DefaultTransport http.RoundTripper = &http.Transport{
 		DialContext: (&net.Dialer{
-			Timeout:   5 * time.Second,
-			KeepAlive: 30 * time.Second,
+			Timeout: 5 * time.Second,
 		}).DialContext,
 		DisableCompression:    true,
 		MaxIdleConns:          5,
@@ -54,6 +53,9 @@ var (
 func init() {
 	DefaultUserAgent = fmt.Sprintf("%s (github.com/segmentio/consul-go)", filepath.Base(os.Args[0]))
 }
+
+// An ID is a general purpose unique identifier.
+type ID string
 
 // A Client exposes an API for communicating with a consul agent.
 //

--- a/client.go
+++ b/client.go
@@ -45,6 +45,9 @@ var (
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
+	// DefaultClient is the default client used when none is specified.
+	DefaultClient = &Client{}
+
 	// DefaultUserAgent is the default user agent used by consul clients when
 	// none has been set.
 	DefaultUserAgent string

--- a/dialer.go
+++ b/dialer.go
@@ -1,0 +1,95 @@
+package consul
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+)
+
+// The Dialer type mirrors the net.Dialer API but uses Consul to resolve service
+// names to network addresses instead of DNS.
+//
+// The Dialer always ignores ports specified in the addreses that it's trying to
+// connect to and uses the ports looked up from Consul instead, unless it was
+// given and address which is a valid IP representation in which case it does
+// not resolve the service name and directly establish the connection.
+//
+// For a full description of each of the fields please refer to the net.Dialer
+// documentation at https://golang.org/pkg/net/#Dialer.
+type Dialer struct {
+	Timeout       time.Duration
+	Deadline      time.Time
+	LocalAddr     net.Addr
+	DualStack     bool
+	FallbackDelay time.Duration
+	KeepAlive     time.Duration
+	Resolver      *Resolver
+}
+
+// Dial establishes a network connection to address, using consul to resolve
+// the address if necessary.
+//
+// For a full description of the method's behavior please refer to the
+// (*net.Dialer).Dial documentation at https://golang.org/pkg/net/#Dialer.Dial.
+func (d *Dialer) Dial(network string, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+// DialContext establishes a network connection to address, using consul to
+// resolve the address if necessary.
+//
+// For a full description of the method's behavior please refer to the
+// (*net.Dialer).Dialcontext documentation at
+// https://golang.org/pkg/net/#Dialer.DialContext.
+func (d *Dialer) DialContext(ctx context.Context, network string, address string) (net.Conn, error) {
+	if host, _ := splitHostPort(address); len(host) != 0 && net.ParseIP(host) == nil {
+		addrs, err := d.resolver().LookupService(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		if len(addrs) == 0 {
+			return nil, fmt.Errorf("no addresses returned by the resolver for %s", host)
+		}
+		address = addrs[0]
+	}
+
+	return (&net.Dialer{
+		Timeout:       d.Timeout,
+		Deadline:      d.Deadline,
+		LocalAddr:     d.LocalAddr,
+		DualStack:     d.DualStack,
+		FallbackDelay: d.FallbackDelay,
+		KeepAlive:     d.KeepAlive,
+	}).DialContext(ctx, network, address)
+}
+
+func (d *Dialer) resolver() *Resolver {
+	if rslv := d.Resolver; rslv != nil {
+		return rslv
+	}
+	return DefaultResolver
+}
+
+// Dial is a wrapper for calling (*Dialer).Dial on a default dialer.
+func Dial(network string, address string) (net.Conn, error) {
+	return (&Dialer{}).Dial(network, address)
+}
+
+// DialContext is a wrapper for calling (*Dialer).DialContext on a default
+// dialer.
+func DialContext(ctx context.Context, network string, address string) (net.Conn, error) {
+	return (&Dialer{}).DialContext(ctx, network, address)
+}
+
+func joinHostPort(host string, port string) string {
+	return net.JoinHostPort(host, port)
+}
+
+func splitHostPort(s string) (string, string) {
+	host, port, err := net.SplitHostPort(s)
+	if err != nil {
+		return s, ""
+	}
+	return host, port
+}

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -1,0 +1,58 @@
+package consul
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/segmentio/objconv/json"
+)
+
+func TestDialer(t *testing.T) {
+	httpServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Write([]byte("Hello World!"))
+	}))
+	defer httpServer.Close()
+	u, _ := url.Parse(httpServer.URL)
+	addr, port := splitHostPort(u.Host)
+
+	consulServer, consulClient := newServerClient(func(res http.ResponseWriter, req *http.Request) {
+		type service struct {
+			Address string
+			Port    int
+		}
+		json.NewEncoder(res).Encode([]struct{ Service service }{{Service: service{addr, atoi(port)}}})
+	})
+	defer consulServer.Close()
+
+	// The HTTP client uses a transport with a resolver that uses consul to
+	// lookup service addresses.
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&Dialer{
+				Resolver: &Resolver{
+					Client: consulClient,
+				},
+			}).DialContext,
+		},
+	}
+
+	res, err := httpClient.Get("http://whatever/")
+	if err != nil {
+		t.Error(err)
+	}
+	b, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+
+	if s := string(b); s != "Hello World!" {
+		t.Error("bad response:", s)
+	}
+}
+
+func atoi(s string) int {
+	v, _ := strconv.Atoi(s)
+	return v
+}

--- a/resolver.go
+++ b/resolver.go
@@ -8,6 +8,9 @@ import (
 
 // A Resolver is a high-level abstraction on top of the Consul service discovery
 // API.
+//
+// The zero-value is a valid Resolver that uses DefaultClient to query the
+// consul agent.
 type Resolver struct {
 	// The client used by the resolver, which may be nil to indicate that a
 	// default client should be used.
@@ -76,7 +79,7 @@ func (rslv *Resolver) client() *Client {
 	if client := rslv.Client; client != nil {
 		return client
 	}
-	return &Client{}
+	return DefaultClient
 }
 
 func queryAppendTags(query Query, tags ...string) Query {

--- a/resolver.go
+++ b/resolver.go
@@ -101,3 +101,8 @@ func queryAppendNodeMeta(query Query, nodeMeta map[string]string) Query {
 	}
 	return query
 }
+
+// DefaultResolver is the Resolver used by a Dialer when non has been specified.
+var DefaultResolver = &Resolver{
+	Near: "_agent",
+}

--- a/resolver.go
+++ b/resolver.go
@@ -22,19 +22,19 @@ type Resolver struct {
 	Near string
 
 	// A list of service tags used to filter the result set. Only addresses of
-	// services that match those tags will be returned by LookupServices.
+	// services that match those tags will be returned by LookupService.
 	ServiceTags []string
 
 	// A set of key/value pairs used to filter the result set. Only addresses of
-	// nodes that have matching metadata will be returned by LookupServices.
+	// nodes that have matching metadata will be returned by LookupService.
 	NodeMeta map[string]string
 }
 
-// LookupServices resolves a service name to a list of addresses using the
+// LookupService resolves a service name to a list of addresses using the
 // resolver's configuration and the given list of extra service tags to narrow
 // the result set. Only addresses of healthy services are returned by the lookup
 // operation.
-func (rslv *Resolver) LookupServices(ctx context.Context, name string, tags ...string) (addrs []string, err error) {
+func (rslv *Resolver) LookupService(ctx context.Context, name string, tags ...string) (addrs []string, err error) {
 	var results []struct {
 		// There are other fields in the response which have been omitted to
 		// avoiding parsing a bunch of throw-away values. Refer to the consul

--- a/resolver.go
+++ b/resolver.go
@@ -1,0 +1,100 @@
+package consul
+
+import (
+	"context"
+	"net"
+	"strconv"
+)
+
+// A Resolver is a high-level abstraction on top of the Consul service discovery
+// API.
+type Resolver struct {
+	// The client used by the resolver, which may be nil to indicate that a
+	// default client should be used.
+	Client *Client
+
+	// Near may be set to the address of a node which is used to sort the list
+	// of resolved addresses based on the estimated round trip time from that
+	// node.
+	//
+	// Setting this field to "_agent" will use the consul agent's node for the
+	// sort.
+	Near string
+
+	// A list of service tags used to filter the result set. Only addresses of
+	// services that match those tags will be returned by LookupServices.
+	ServiceTags []string
+
+	// A set of key/value pairs used to filter the result set. Only addresses of
+	// nodes that have matching metadata will be returned by LookupServices.
+	NodeMeta map[string]string
+}
+
+// LookupServices resolves a service name to a list of addresses using the
+// resolver's configuration and the given list of extra service tags to narrow
+// the result set. Only addresses of healthy services are returned by the lookup
+// operation.
+func (rslv *Resolver) LookupServices(ctx context.Context, name string, tags ...string) (addrs []string, err error) {
+	var results []struct {
+		// There are other fields in the response which have been omitted to
+		// avoiding parsing a bunch of throw-away values. Refer to the consul
+		// documentation for a full description of the schema:
+		// https://www.consul.io/api/health.html#list-nodes-for-service
+		Service struct {
+			Address string
+			Port    int
+		}
+	}
+
+	query := make(Query, 0, 2+len(rslv.NodeMeta)+len(rslv.ServiceTags)+len(tags))
+	query = append(query, Param{Name: "passing"})
+	query = queryAppendNodeMeta(query, rslv.NodeMeta)
+	query = queryAppendTags(query, rslv.ServiceTags...)
+	query = queryAppendTags(query, tags...)
+
+	if near := rslv.Near; len(near) != 0 {
+		query = append(query, Param{
+			Name:  "near",
+			Value: near,
+		})
+	}
+
+	if err = rslv.client().Get(ctx, "/v1/health/service/"+name, query, &results); err != nil {
+		return
+	}
+
+	addrs = make([]string, len(results))
+
+	for i, res := range results {
+		addrs[i] = net.JoinHostPort(res.Service.Address, strconv.Itoa(res.Service.Port))
+	}
+
+	return
+}
+
+func (rslv *Resolver) client() *Client {
+	if client := rslv.Client; client != nil {
+		return client
+	}
+	return &Client{}
+}
+
+func queryAppendTags(query Query, tags ...string) Query {
+	for _, tag := range tags {
+		query = append(query, Param{
+			Name:  "tag",
+			Value: tag,
+		})
+	}
+	return query
+}
+
+func queryAppendNodeMeta(query Query, nodeMeta map[string]string) Query {
+	for key, value := range nodeMeta {
+		query = append(query, Param{
+			Name:  "node-meta",
+			Value: key + ":" + value,
+		})
+	}
+	return query
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -2,11 +2,12 @@ package consul
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/segmentio/objconv/json"
 )
 
 func TestResolver(t *testing.T) {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,0 +1,75 @@
+package consul
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestResolver(t *testing.T) {
+	t.Run("LookupServices", testLookupServices)
+}
+
+func testLookupServices(t *testing.T) {
+	server, client := newServerClient(func(res http.ResponseWriter, req *http.Request) {
+		if req.Method != "GET" {
+			t.Error("bad method:", req.Method)
+		}
+
+		if req.URL.Path != "/v1/health/service/1234" {
+			t.Error("bad URL path:", req.URL.Path)
+		}
+
+		foundQuery := req.URL.Query()
+		expectQuery := url.Values{
+			"passing":   {""},
+			"dc":        {"dc1"},
+			"near":      {"_agent"},
+			"tag":       {"A", "B", "C", "a", "b", "c"},
+			"node-meta": {"answer:42"},
+		}
+		if !reflect.DeepEqual(foundQuery, expectQuery) {
+			t.Error("bad URL query:")
+			t.Logf("expected: %#v", expectQuery)
+			t.Logf("found:    %#v", foundQuery)
+		}
+
+		type service struct {
+			Address string
+			Port    int
+		}
+		json.NewEncoder(res).Encode([]struct {
+			Service service
+		}{
+			{Service: service{Address: "192.168.0.1", Port: 4242}},
+			{Service: service{Address: "192.168.0.2", Port: 4242}},
+			{Service: service{Address: "192.168.0.3", Port: 4242}},
+		})
+		return
+	})
+	defer server.Close()
+
+	rslv := Resolver{
+		Client:      client,
+		Near:        "_agent",
+		ServiceTags: []string{"A", "B", "C"},
+		NodeMeta:    map[string]string{"answer": "42"},
+	}
+
+	addrs, err := rslv.LookupServices(context.Background(), "1234", "a", "b", "c")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(addrs, []string{
+		"192.168.0.1:4242",
+		"192.168.0.2:4242",
+		"192.168.0.3:4242",
+	}) {
+		t.Error("bad addresses returned:", addrs)
+	}
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestResolver(t *testing.T) {
-	t.Run("LookupServices", testLookupServices)
+	t.Run("LookupService", testLookupService)
 }
 
-func testLookupServices(t *testing.T) {
+func testLookupService(t *testing.T) {
 	server, client := newServerClient(func(res http.ResponseWriter, req *http.Request) {
 		if req.Method != "GET" {
 			t.Error("bad method:", req.Method)
@@ -59,7 +59,7 @@ func testLookupServices(t *testing.T) {
 		NodeMeta:    map[string]string{"answer": "42"},
 	}
 
-	addrs, err := rslv.LookupServices(context.Background(), "1234", "a", "b", "c")
+	addrs, err := rslv.LookupService(context.Background(), "1234", "a", "b", "c")
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Hey guys, here's the first abstraction on top of the consul client, it exposes a high-level interface for resolving a service name to a list of addresses.

The original documentation is [here](https://www.consul.io/api/health.html#list-nodes-for-service)

Take a look and let me know if you think something should be changed.