### PR TITLE
add dialer

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -1,0 +1,101 @@
+package consul
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+)
+
+// The Dialer type mirrors the net.Dialer API but uses Consul to resolve service
+// names to network addresses instead of DNS.
+//
+// For a full description of each of the fields please refer to the net.Dialer
+// documentation at https://golang.org/pkg/net/#Dialer.
+type Dialer struct {
+	Timeout       time.Duration
+	Deadline      time.Time
+	LocalAddr     net.Addr
+	DualStack     bool
+	FallbackDelay time.Duration
+	KeepAlive     time.Duration
+	Resolver      *Resolver
+}
+
+// Dial establishes a network connection to address, using consul to resolve
+// the address if necessary.
+//
+// For a full description of the method's behavior please refer to the
+// (*net.Dialer).Dial documentation at https://golang.org/pkg/net/#Dialer.Dial.
+func (d *Dialer) Dial(network string, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+// DialContext establishes a network connection to address, using consul to
+// resolve the address if necessary.
+//
+// For a full description of the method's behavior please refer to the
+// (*net.Dialer).Dialcontext documentation at
+// https://golang.org/pkg/net/#Dialer.DialContext.
+func (d *Dialer) DialContext(ctx context.Context, network string, address string) (net.Conn, error) {
+	if host, port := splitHostPort(address); len(host) != 0 && net.ParseIP(host) == nil {
+		addrs, err := d.resolver().LookupService(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		if len(addrs) == 0 {
+			return nil, fmt.Errorf("no addresses returned by the resolver for %s", host)
+		}
+		address = addrs[0]
+
+		if port != 0 {
+			address, _ = splitHostPort(address)
+			address = joinHostPort(address, port)
+		}
+	}
+
+	return (&net.Dialer{
+		Timeout:       d.Timeout,
+		Deadline:      d.Deadline,
+		LocalAddr:     d.LocalAddr,
+		DualStack:     d.DualStack,
+		FallbackDelay: d.FallbackDelay,
+		KeepAlive:     d.KeepAlive,
+	}).DialContext(ctx, network, address)
+}
+
+func (d *Dialer) resolver() *Resolver {
+	if rslv := d.Resolver; rslv != nil {
+		return rslv
+	}
+	return DefaultResolver
+}
+
+// Dial is a wrapper for calling (*Dialer).Dial on a default dialer.
+func Dial(network string, address string) (net.Conn, error) {
+	return (&Dialer{}).Dial(network, address)
+}
+
+// DialContext is a wrapper for calling (*Dialer).DialContext on a default
+// dialer.
+func DialContext(ctx context.Context, network string, address string) (net.Conn, error) {
+	return (&Dialer{}).DialContext(ctx, network, address)
+}
+
+func joinHostPort(s string, p int) string {
+	return net.JoinHostPort(s, strconv.Itoa(p))
+}
+
+func splitHostPort(s string) (string, int) {
+	host, port, err := net.SplitHostPort(s)
+	if err != nil {
+		return s, 0
+	}
+	return host, atoi(port)
+}
+
+func atoi(s string) int {
+	v, _ := strconv.Atoi(s)
+	return v
+}

--- a/dialer.go
+++ b/dialer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strconv"
 	"time"
 )
 
@@ -49,7 +48,7 @@ func (d *Dialer) DialContext(ctx context.Context, network string, address string
 		}
 		address = addrs[0]
 
-		if port != 0 {
+		if len(port) != 0 {
 			address, _ = splitHostPort(address)
 			address = joinHostPort(address, port)
 		}
@@ -83,19 +82,17 @@ func DialContext(ctx context.Context, network string, address string) (net.Conn,
 	return (&Dialer{}).DialContext(ctx, network, address)
 }
 
-func joinHostPort(s string, p int) string {
-	return net.JoinHostPort(s, strconv.Itoa(p))
+func joinHostPort(host string, port string) string {
+	return net.JoinHostPort(host, port)
 }
 
-func splitHostPort(s string) (string, int) {
+func splitHostPort(s string) (string, string) {
 	host, port, err := net.SplitHostPort(s)
 	if err != nil {
-		return s, 0
+		return s, ""
 	}
-	return host, atoi(port)
-}
-
-func atoi(s string) int {
-	v, _ := strconv.Atoi(s)
-	return v
+	if port == "0" {
+		port = ""
+	}
+	return host, port
 }

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -1,12 +1,13 @@
 package consul
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/segmentio/objconv/json"
 )
 
 func TestDialer(t *testing.T) {

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/segmentio/objconv/json"
@@ -23,7 +24,7 @@ func TestDialer(t *testing.T) {
 			Address string
 			Port    int
 		}
-		json.NewEncoder(res).Encode([]struct{ Service service }{{Service: service{addr, port}}})
+		json.NewEncoder(res).Encode([]struct{ Service service }{{Service: service{addr, atoi(port)}}})
 	})
 	defer consulServer.Close()
 
@@ -39,7 +40,7 @@ func TestDialer(t *testing.T) {
 		},
 	}
 
-	res, err := httpClient.Get("http://whaetever:0/")
+	res, err := httpClient.Get("http://whatever:0/")
 	if err != nil {
 		t.Error(err)
 	}
@@ -49,4 +50,9 @@ func TestDialer(t *testing.T) {
 	if s := string(b); s != "Hello World!" {
 		t.Error("bad response:", s)
 	}
+}
+
+func atoi(s string) int {
+	v, _ := strconv.Atoi(s)
+	return v
 }

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -40,7 +40,7 @@ func TestDialer(t *testing.T) {
 		},
 	}
 
-	res, err := httpClient.Get("http://whatever:0/")
+	res, err := httpClient.Get("http://whatever/")
 	if err != nil {
 		t.Error(err)
 	}

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -1,0 +1,51 @@
+package consul
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestDialer(t *testing.T) {
+	httpServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Write([]byte("Hello World!"))
+	}))
+	defer httpServer.Close()
+	u, _ := url.Parse(httpServer.URL)
+	addr, port := splitHostPort(u.Host)
+
+	consulServer, consulClient := newServerClient(func(res http.ResponseWriter, req *http.Request) {
+		type service struct {
+			Address string
+			Port    int
+		}
+		json.NewEncoder(res).Encode([]struct{ Service service }{{Service: service{addr, port}}})
+	})
+	defer consulServer.Close()
+
+	// The HTTP client uses a transport with a resolver that uses consul to
+	// lookup service addresses.
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&Dialer{
+				Resolver: &Resolver{
+					Client: consulClient,
+				},
+			}).DialContext,
+		},
+	}
+
+	res, err := httpClient.Get("http://whaetever:0/")
+	if err != nil {
+		t.Error(err)
+	}
+	b, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+
+	if s := string(b); s != "Hello World!" {
+		t.Error("bad response:", s)
+	}
+}

--- a/resolver.go
+++ b/resolver.go
@@ -101,3 +101,8 @@ func queryAppendNodeMeta(query Query, nodeMeta map[string]string) Query {
 	}
 	return query
 }
+
+// DefaultResolver is the Resolver used by a Dialer when non has been specified.
+var DefaultResolver = &Resolver{
+	Near: "_agent",
+}


### PR DESCRIPTION
Here's the implementation of `Dialer` that mirrors the `net.Dialer` API but uses Consul to resolve service names instead of DNS.

The test gives an example of how to use it with an `http.Transport` to have all requests routed to services registered to Consul.

Please take a look and let me know if something should be changed.