### PR TITLE
Listener

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -40,14 +40,14 @@ type CheckConfig struct {
 	ID                             CheckID     `json:",omitempty"`
 	Name                           string      `json:",omitempty"`
 	Notes                          string      `json:",omitempty"`
-	DeregisterCriticalServiceAfter string      `json:",omitempty"`
+	DeregisterCriticalServiceAfter Seconds     `json:",omitempty"`
 	Script                         string      `json:",omitempty"`
 	DockerContainerID              string      `json:",omitempty"`
 	Shell                          string      `json:",omitempty"`
 	HTTP                           string      `json:",omitempty"`
 	TCP                            string      `json:",omitempty"`
-	Interval                       string      `json:",omitempty"`
-	TTL                            string      `json:",omitempty"`
+	Interval                       Seconds     `json:",omitempty"`
+	TTL                            Seconds     `json:",omitempty"`
 	Status                         CheckStatus `json:",omitempty"`
 	ServiceID                      ServiceID   `json:",omitempty"`
 	TLSSkipVerify                  bool        `json:",omitempty"`

--- a/agent.go
+++ b/agent.go
@@ -1,0 +1,66 @@
+package consul
+
+import "context"
+
+// ServiceID represents a unique identifier for services.
+type ServiceID string
+
+// ServiceConfig is used to configure how a service is registered.
+type ServiceConfig struct {
+	ID                ServiceID     `json:",omitempty"`
+	Name              string        `json:",omitempty"`
+	Tags              []string      `json:",omitempty"`
+	Address           string        `json:",omitempty"`
+	Port              int           `json:",omitempty"`
+	EnableTagOverride bool          `json:",omitempty"`
+	Checks            []CheckConfig `json:",omitempty"`
+}
+
+// CheckID represents a unique identifier for health checks.
+type CheckID string
+
+// CheckStatus is an enumeration of the various states of the health check.
+type CheckStatus string
+
+const (
+	// Passing indicates that a health check has detected no issues.
+	Passing CheckStatus = "passing"
+
+	// Warning indicates that a health check has detected issues but the
+	// the service can still operate.
+	Warning CheckStatus = "warning"
+
+	// Critical indicates that a health check has failed and recovery requires
+	// human intervention.
+	Critical CheckStatus = "critical"
+)
+
+// CheckConfig is used to configure the checks on a service being registered.
+type CheckConfig struct {
+	ID                             CheckID     `json:",omitempty"`
+	Name                           string      `json:",omitempty"`
+	Notes                          string      `json:",omitempty"`
+	DeregisterCriticalServiceAfter string      `json:",omitempty"`
+	Script                         string      `json:",omitempty"`
+	DockerContainerID              string      `json:",omitempty"`
+	Shell                          string      `json:",omitempty"`
+	HTTP                           string      `json:",omitempty"`
+	TCP                            string      `json:",omitempty"`
+	Interval                       string      `json:",omitempty"`
+	TTL                            string      `json:",omitempty"`
+	Status                         CheckStatus `json:",omitempty"`
+	ServiceID                      ServiceID   `json:",omitempty"`
+	TLSSkipVerify                  bool        `json:",omitempty"`
+}
+
+// RegisterService registers a service to the consul agent.
+func (c *Client) RegisterService(ctx context.Context, service ServiceConfig) (err error) {
+	err = c.Put(ctx, "/v1/agent/service/register", nil, service, nil)
+	return
+}
+
+// DeregisterService deregisters a service from the consul agent.
+func (c *Client) DeregisterService(ctx context.Context, service ServiceID) (err error) {
+	err = c.Put(ctx, "/v1/agent/service/deregister/"+string(service), nil, nil, nil)
+	return
+}

--- a/dialer.go
+++ b/dialer.go
@@ -82,10 +82,6 @@ func DialContext(ctx context.Context, network string, address string) (net.Conn,
 	return (&Dialer{}).DialContext(ctx, network, address)
 }
 
-func joinHostPort(host string, port string) string {
-	return net.JoinHostPort(host, port)
-}
-
 func splitHostPort(s string) (string, string) {
 	host, port, err := net.SplitHostPort(s)
 	if err != nil {

--- a/dialer.go
+++ b/dialer.go
@@ -7,11 +7,11 @@ import (
 	"time"
 )
 
-// The Dialer type mirrors the net.Dialer API but uses Consul to resolve service
+// The Dialer type mirrors the net.Dialer API but uses consul to resolve service
 // names to network addresses instead of DNS.
 //
 // The Dialer always ignores ports specified in the addreses that it's trying to
-// connect to and uses the ports looked up from Consul instead, unless it was
+// connect to and uses the ports looked up from consul instead, unless it was
 // given and address which is a valid IP representation in which case it does
 // not resolve the service name and directly establish the connection.
 //

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -43,8 +43,9 @@ func TestDialer(t *testing.T) {
 	res, err := httpClient.Get("http://whatever/")
 	if err != nil {
 		t.Error(err)
+		return
 	}
-	b, err := ioutil.ReadAll(res.Body)
+	b, _ := ioutil.ReadAll(res.Body)
 	res.Body.Close()
 
 	if s := string(b); s != "Hello World!" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+
+services:
+  consul:
+    image: consul:latest
+    command: agent -server -dev -log-level debug -bind 0.0.0.0 -client 0.0.0.0
+    ports:
+      - 8500:8500

--- a/listener.go
+++ b/listener.go
@@ -1,0 +1,188 @@
+package consul
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Listen creates a listener that accept connections on the given network and
+// address, and registers to consul using the default client.
+//
+// The address may be in a URL format like "host:port/name/id?advertize=address"
+// to configure how the listener registers to consul.
+// The host, name, id, and advertized address parts are optional.
+//
+func Listen(network string, address string) (net.Listener, error) {
+	return ListenWithClient(network, address, nil)
+}
+
+// ListenWithClient creates a listener that accept connections on the given
+// network and address, and registers to consul with client.
+//
+// If client is nil, the default client is used instead.
+func ListenWithClient(network string, address string, client *Client) (net.Listener, error) {
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+	default:
+		return nil, fmt.Errorf("unsupported network: %s", network)
+	}
+
+	config, err := parseAddress(address)
+	if err != nil {
+		return nil, err
+	}
+
+	lstn, err := net.Listen(network, config.address)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(config.advertize) == 0 {
+		config.advertize = lstn.Addr().String()
+	}
+
+	if client == nil {
+		client = DefaultClient
+	}
+
+	l := &listener{
+		lstn:      lstn,
+		client:    client,
+		serviceID: ServiceID(config.id),
+	}
+
+	if err := l.register(config); err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+type listener struct {
+	lstn      net.Listener
+	client    *Client
+	serviceID ServiceID
+}
+
+func (l *listener) Accept() (net.Conn, error) {
+	return l.lstn.Accept()
+}
+
+func (l *listener) Addr() net.Addr {
+	return l.lstn.Addr()
+}
+
+func (l *listener) Close() error {
+	l.deregister()
+	return l.lstn.Close()
+}
+
+func (l *listener) register(config listenConfig) error {
+	address, stringPort, err := net.SplitHostPort(config.advertize)
+	if err != nil {
+		return err
+	}
+
+	port, err := strconv.Atoi(stringPort)
+	if err != nil {
+		return err
+	}
+
+	if len(config.id) == 0 {
+		config.id = config.name
+	}
+
+	if len(config.timeout) == 0 {
+		config.timeout = "60m"
+	}
+
+	if len(config.notes) == 0 {
+		config.notes = "Ensure that consul can establish a TCP connection to the service"
+	}
+
+	if len(config.interval) == 0 {
+		config.interval = "10s"
+	}
+
+	return l.client.RegisterService(context.TODO(), ServiceConfig{
+		ID:                ServiceID(config.id),
+		Name:              config.name,
+		Address:           address,
+		Port:              port,
+		EnableTagOverride: true,
+		Checks: []CheckConfig{{
+			DeregisterCriticalServiceAfter: config.timeout,
+			TCP:      config.advertize,
+			Notes:    config.notes,
+			Interval: config.interval,
+		}},
+	})
+}
+
+func (l *listener) deregister() error {
+	return l.client.DeregisterService(context.TODO(), l.serviceID)
+}
+
+type listenConfig struct {
+	address   string
+	name      string
+	id        string
+	advertize string
+	timeout   string
+	notes     string
+	interval  string
+}
+
+func parseAddress(s string) (config listenConfig, err error) {
+	var u *url.URL
+
+	if u, err = url.Parse(s); err != nil {
+		return
+	}
+
+	switch path := strings.Split(u.Path, "/"); len(path) {
+	case 0:
+	case 1:
+		config.name = path[0]
+	case 2:
+		config.name, config.id = path[0], path[1]
+	default:
+		err = fmt.Errorf("bad listener address: too many path elements: %s", s)
+		return
+	}
+
+	q := u.Query()
+
+	if config.advertize = q.Get("advertize"); len(config.advertize) != 0 {
+		var host string
+		var port string
+		var v int
+
+		if host, port, err = net.SplitHostPort(config.advertize); err != nil {
+			err = fmt.Errorf("bad listener address: invalid advertized address: %s", err)
+			return
+		}
+
+		if net.ParseIP(host) == nil {
+			err = fmt.Errorf("bad listener address: the advertized address must be a valid IP: %s", s)
+			return
+		}
+
+		if v, err = strconv.Atoi(port); err != nil {
+			err = fmt.Errorf("bad listener address: non-numeric port in advertized address: %s", err)
+			return
+		} else if v < 0 {
+			err = fmt.Errorf("bad listener address: negative port number in advertized address: %s", s)
+			return
+		}
+	}
+
+	config.timeout = q.Get("deregister_critical_service_after")
+	config.notes = q.Get("notes")
+	config.interval = q.Get("interval")
+	return
+}

--- a/listener_test.go
+++ b/listener_test.go
@@ -1,0 +1,54 @@
+package consul
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestListener(t *testing.T) {
+	if os.Getenv("CIRCLE_PROJECT_USERNAME") != "" {
+		// Consul takes a while to start...
+		time.Sleep(10 * time.Second)
+	}
+
+	httpLstn, err := (&Listener{
+		ServiceName: "test-listener",
+	}).ListenContext(context.Background(), "tcp", ":0")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer httpLstn.Close()
+
+	httpServer := &http.Server{
+		Handler: http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.Write([]byte("Hello World!"))
+		}),
+	}
+	go httpServer.Serve(httpLstn)
+	defer httpServer.Close()
+
+	// The HTTP client uses a transport with a resolver that uses consul to
+	// lookup service addresses.
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&Dialer{}).DialContext,
+		},
+	}
+
+	res, err := httpClient.Get("http://test-listener/")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	b, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+
+	if s := string(b); s != "Hello World!" {
+		t.Error("bad response:", s)
+	}
+}

--- a/listener_test.go
+++ b/listener_test.go
@@ -45,7 +45,7 @@ func TestListener(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	b, err := ioutil.ReadAll(res.Body)
+	b, _ := ioutil.ReadAll(res.Body)
 	res.Body.Close()
 
 	if s := string(b); s != "Hello World!" {

--- a/resolver.go
+++ b/resolver.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// A Resolver is a high-level abstraction on top of the Consul service discovery
+// A Resolver is a high-level abstraction on top of the consul service discovery
 // API.
 //
 // The zero-value is a valid Resolver that uses DefaultClient to query the


### PR DESCRIPTION
Here's the implementation of a `net.Listener` which is automatically registered to Consul, and deregistered when it is closed.

The test shows an example of how it would be used with an HTTP server.

Please take a look and let me know what you think about it.