### PR TITLE
user net.Addr to make it harder to do the wrong thing

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -51,7 +51,7 @@ func (d *Dialer) DialContext(ctx context.Context, network string, address string
 		if len(addrs) == 0 {
 			return nil, fmt.Errorf("no addresses returned by the resolver for %s", host)
 		}
-		address = addrs[0]
+		address = addrs[0].String()
 	}
 
 	return (&net.Dialer{

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -66,10 +67,10 @@ func testLookupService(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !reflect.DeepEqual(addrs, []string{
-		"192.168.0.1:4242",
-		"192.168.0.2:4242",
-		"192.168.0.3:4242",
+	if !reflect.DeepEqual(addrs, []net.Addr{
+		&serviceAddr{"192.168.0.1", 4242},
+		&serviceAddr{"192.168.0.2", 4242},
+		&serviceAddr{"192.168.0.3", 4242},
 	}) {
 		t.Error("bad addresses returned:", addrs)
 	}


### PR DESCRIPTION
This PR changes the signature of `(*Resolver).LookupService` to return a `[]net.Addr` instead of `[]string`. Stronger typing makes it harder to do the wrong thing.