### PR TITLE
Resolver cache

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -3,7 +3,10 @@ package consul
 import (
 	"context"
 	"net"
+	"runtime"
 	"strconv"
+	"sync"
+	"time"
 )
 
 // A Resolver is a high-level abstraction on top of the consul service discovery
@@ -31,13 +34,27 @@ type Resolver struct {
 	// A set of key/value pairs used to filter the result set. Only addresses of
 	// nodes that have matching metadata will be returned by LookupService.
 	NodeMeta map[string]string
+
+	// Cache used by the resolver to reduce the number of round-trips to consul.
+	// If set to nil then no cache is used.
+	//
+	// ResolverCache instances should not be shared by multiple resolvers
+	// because the cache uses the service name as a lookup key, but the resolver
+	// may apply filters based on its configuration.
+	Cache *ResolverCache
 }
 
 // LookupService resolves a service name to a list of addresses using the
-// resolver's configuration and the given list of extra service tags to narrow
-// the result set. Only addresses of healthy services are returned by the lookup
-// operation.
-func (rslv *Resolver) LookupService(ctx context.Context, name string, tags ...string) (addrs []net.Addr, err error) {
+// resolver's configuration to narrow the result set. Only addresses of healthy
+// services are returned by the lookup operation.
+func (rslv *Resolver) LookupService(ctx context.Context, name string) ([]net.Addr, error) {
+	if rslv.Cache != nil {
+		return rslv.Cache.LookupService(ctx, name, rslv.lookupService)
+	}
+	return rslv.lookupService(ctx, name)
+}
+
+func (rslv *Resolver) lookupService(ctx context.Context, name string) (addrs []net.Addr, err error) {
 	var results []struct {
 		// There are other fields in the response which have been omitted to
 		// avoiding parsing a bunch of throw-away values. Refer to the consul
@@ -49,11 +66,22 @@ func (rslv *Resolver) LookupService(ctx context.Context, name string, tags ...st
 		}
 	}
 
-	query := make(Query, 0, 2+len(rslv.NodeMeta)+len(rslv.ServiceTags)+len(tags))
+	query := make(Query, 0, 2+len(rslv.NodeMeta)+len(rslv.ServiceTags))
 	query = append(query, Param{Name: "passing"})
-	query = queryAppendNodeMeta(query, rslv.NodeMeta)
-	query = queryAppendTags(query, rslv.ServiceTags...)
-	query = queryAppendTags(query, tags...)
+
+	for key, value := range rslv.NodeMeta {
+		query = append(query, Param{
+			Name:  "node-meta",
+			Value: key + ":" + value,
+		})
+	}
+
+	for _, tag := range rslv.ServiceTags {
+		query = append(query, Param{
+			Name:  "tag",
+			Value: tag,
+		})
+	}
 
 	if near := rslv.Near; len(near) != 0 {
 		query = append(query, Param{
@@ -85,26 +113,6 @@ func (rslv *Resolver) client() *Client {
 	return DefaultClient
 }
 
-func queryAppendTags(query Query, tags ...string) Query {
-	for _, tag := range tags {
-		query = append(query, Param{
-			Name:  "tag",
-			Value: tag,
-		})
-	}
-	return query
-}
-
-func queryAppendNodeMeta(query Query, nodeMeta map[string]string) Query {
-	for key, value := range nodeMeta {
-		query = append(query, Param{
-			Name:  "node-meta",
-			Value: key + ":" + value,
-		})
-	}
-	return query
-}
-
 // DefaultResolver is the Resolver used by a Dialer when non has been specified.
 var DefaultResolver = &Resolver{
 	Near: "_agent",
@@ -112,8 +120,8 @@ var DefaultResolver = &Resolver{
 
 // LookupService is a wrapper around the default resolver's LookupService
 // method.
-func LookupService(ctx context.Context, name string, tags ...string) ([]net.Addr, error) {
-	return DefaultResolver.LookupService(ctx, name, tags...)
+func LookupService(ctx context.Context, name string) ([]net.Addr, error) {
+	return DefaultResolver.LookupService(ctx, name)
 }
 
 type serviceAddr struct {
@@ -127,4 +135,142 @@ func (a *serviceAddr) Network() string {
 
 func (a *serviceAddr) String() string {
 	return net.JoinHostPort(a.addr, strconv.Itoa(a.port))
+}
+
+// LookupServiceFunc is the signature of functions that can be used to lookup
+// service names.
+type LookupServiceFunc func(context.Context, string) ([]net.Addr, error)
+
+// The ResolverCache type provides the implementation of a caching layer for
+// service name resolutions.
+//
+// Instances of ResolverCache are save to use concurrently from multiple
+// goroutines.
+type ResolverCache struct {
+	// The maximum age of cache entries. If zero, a default value of 1 second is
+	// used.
+	Timeout time.Duration
+
+	once sync.Once
+	cmap *resolverCacheMap
+}
+
+// LookupService resolves a service name by fetching the address list from the
+// cache, or calling lookup if the name did not exist.
+func (cache *ResolverCache) LookupService(ctx context.Context, name string, lookup LookupServiceFunc) ([]net.Addr, error) {
+	cache.once.Do(func() {
+		cache.init()
+	})
+
+	now := time.Now()
+	exp := now.Add(cache.timeout())
+	entry, locked := cache.cmap.lookup(name, now, exp)
+
+	if locked {
+		// TODO: check the error type here and discard things like context
+		// cancellations and timeouts?
+		entry.addrs, entry.err = lookup(ctx, name)
+		entry.mutex.Unlock()
+	}
+
+	entry.mutex.RLock()
+	addrs, err := entry.addrs, entry.err
+	entry.mutex.RUnlock()
+	return addrs, err
+}
+
+func (cache *ResolverCache) init() {
+	cache.cmap = &resolverCacheMap{
+		entries: make(map[string]*resolverCacheEntry),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runtime.SetFinalizer(cache, func(_ *ResolverCache) { cancel() })
+
+	interval := cache.timeout() / 2
+	go cache.cmap.autoDeleteExpired(ctx, interval)
+}
+
+func (cache *ResolverCache) timeout() time.Duration {
+	if timeout := cache.Timeout; timeout != 0 {
+		return cache.Timeout
+	}
+	return 1 * time.Second
+}
+
+type resolverCacheMap struct {
+	mutex   sync.RWMutex
+	entries map[string]*resolverCacheEntry
+}
+
+type resolverCacheEntry struct {
+	mutex    sync.RWMutex
+	name     string
+	addrs    []net.Addr
+	err      error
+	expireAt time.Time
+}
+
+func (cmap *resolverCacheMap) lookup(name string, now time.Time, exp time.Time) (entry *resolverCacheEntry, locked bool) {
+	cmap.mutex.RLock()
+	entry = cmap.entries[name]
+	cmap.mutex.RUnlock()
+
+	if entry == nil {
+		cmap.mutex.Lock()
+
+		if entry = cmap.entries[name]; entry == nil {
+			entry, locked = &resolverCacheEntry{name: name, expireAt: exp}, true
+			entry.mutex.Lock()
+			cmap.entries[name] = entry
+		}
+
+		cmap.mutex.Unlock()
+	}
+
+	return
+}
+
+func (cmap *resolverCacheMap) delete(entry *resolverCacheEntry) {
+	cmap.mutex.Lock()
+
+	if cmap.entries[entry.name] == entry {
+		delete(cmap.entries, entry.name)
+	}
+
+	cmap.mutex.Unlock()
+}
+
+func (cmap *resolverCacheMap) autoDeleteExpired(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			cmap.deleteExpired(now)
+		}
+	}
+}
+
+func (cmap *resolverCacheMap) deleteExpired(now time.Time) {
+	for _, entry := range cmap.listExpired(now) {
+		cmap.delete(entry)
+	}
+}
+
+func (cmap *resolverCacheMap) listExpired(now time.Time) []*resolverCacheEntry {
+	cmap.mutex.RLock()
+	entries := make([]*resolverCacheEntry, 0, len(cmap.entries))
+
+	for _, entry := range cmap.entries {
+		if now.After(entry.expireAt) {
+			entries = append(entries, entry)
+		}
+	}
+
+	cmap.mutex.RUnlock()
+	return entries
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -102,19 +102,21 @@ func TestResolverCache(t *testing.T) {
 			return list, nil
 		}
 
-		for i := 0; i != 4; i++ {
+		// Loop for 30ms, there should 4 cache misses due to prefetching at
+		// 0ms, 9ms, 19ms, and 29ms.
+		for now, exp := time.Now(), time.Now().Add(30*time.Millisecond); now.Before(exp); now = time.Now() {
 			addrs, err := cache.LookupService(context.Background(), "", lookup)
 
 			if err != nil {
-				t.Errorf("error returned by service lookup #%d: %s", i, err)
+				t.Error("error returned by service lookup:", err)
 			}
 
 			if !reflect.DeepEqual(addrs, list) {
-				t.Errorf("bad address list returned by service lookup #%d: %s", i, addrs)
+				t.Error("bad address list returned by service lookup:", err)
 			}
 		}
 
-		if n := atomic.LoadInt32(&miss); n != 1 {
+		if n := atomic.LoadInt32(&miss); n != 4 {
 			t.Error("bad number of cache misses:", n)
 		}
 	})
@@ -136,11 +138,11 @@ func TestResolverCache(t *testing.T) {
 			addrs, err := cache.LookupService(context.Background(), "", lookup)
 
 			if err != nil {
-				t.Errorf("error returned by service lookup #%d: %s", i, err)
+				t.Error("error returned by service lookup:", err)
 			}
 
 			if !reflect.DeepEqual(addrs, list) {
-				t.Errorf("bad address list returned by service lookup #%d: %s", i, addrs)
+				t.Error("bad address list returned by service lookup:", addrs)
 			}
 
 			// sleep for a little while to let the cache entries expire


### PR DESCRIPTION
The PR adds a caching layer to the `Resolver`. The cache is time-based and entries are removed from the cache when they reach their expiration time. It also implements a non-blocking prefetching to prevent most cache misses on _popular_ service names.

Please take a look and let me know if something should be changed.