### PR TITLE
add endpoint coordinates

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1,6 +1,71 @@
 package consul
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// Agent exposes methods to get information about the agent that a client is
+// configured to connect to.
+type Agent struct {
+	// Client
+	Client *Client
+
+	// Configures how often the state is updated. If zero, the state is updated
+	// every second.
+	Timeout time.Duration
+
+	// Cached agent configuration.
+	config cachedValue
+}
+
+// NodeName fetches the name of the node that the consul agent is running on.
+func (a *Agent) NodeName(ctx context.Context) (string, error) {
+	c, err := a.load(ctx)
+	if err != nil {
+		return "", err
+	}
+	return c.Config.NodeName, nil
+}
+
+func (a *Agent) client() *Client {
+	if client := a.Client; client != nil {
+		return client
+	}
+	return DefaultClient
+}
+
+func (a *Agent) timeout() time.Duration {
+	if timeout := a.Timeout; timeout != 0 {
+		return timeout
+	}
+	return 1 * time.Second
+}
+
+func (a *Agent) load(ctx context.Context) (*agentConfig, error) {
+	now := time.Now()
+	exp := now.Add(a.timeout())
+
+	val, err := a.config.lookup(now, exp, func() (interface{}, error) {
+		config, err := a.client().agentConfig(ctx)
+		return &config, err
+	})
+
+	config, _ := val.(*agentConfig)
+	return config, err
+}
+
+// DefaultAgent is an agent configured to expose the agent information of the
+// consul agent that the default client connects to.
+var DefaultAgent = &Agent{}
+
+type agentConfig struct {
+	// This is a partial definition of the agent configuration object returned
+	// in response to a call to /v1/agent/self.
+	Config struct {
+		NodeName string
+	}
+}
 
 type serviceConfig struct {
 	ID                string        `json:",omitempty"`
@@ -27,6 +92,11 @@ type checkConfig struct {
 	Status                         string `json:",omitempty"`
 	ServiceID                      string `json:",omitempty"`
 	TLSSkipVerify                  bool   `json:",omitempty"`
+}
+
+func (c *Client) agentConfig(ctx context.Context) (config agentConfig, err error) {
+	err = c.Get(ctx, "/v1/agent/self", nil, &config)
+	return
 }
 
 func (c *Client) registerService(ctx context.Context, service serviceConfig) (err error) {

--- a/agent.go
+++ b/agent.go
@@ -13,7 +13,7 @@ type Agent struct {
 
 	// Configures how often the state is updated. If zero, the state is updated
 	// every second.
-	Timeout time.Duration
+	CacheTimeout time.Duration
 
 	// Cached agent configuration.
 	config cachedValue
@@ -35,16 +35,16 @@ func (a *Agent) client() *Client {
 	return DefaultClient
 }
 
-func (a *Agent) timeout() time.Duration {
-	if timeout := a.Timeout; timeout != 0 {
-		return timeout
+func (a *Agent) cacheTimeout() time.Duration {
+	if cacheTimeout := a.CacheTimeout; cacheTimeout != 0 {
+		return cacheTimeout
 	}
 	return 1 * time.Second
 }
 
 func (a *Agent) load(ctx context.Context) (*agentConfig, error) {
 	now := time.Now()
-	exp := now.Add(a.timeout())
+	exp := now.Add(a.cacheTimeout())
 
 	val, err := a.config.lookup(now, exp, func() (interface{}, error) {
 		config, err := a.client().agentConfig(ctx)

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,0 +1,20 @@
+package consul
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAgent(t *testing.T) {
+	t.Run("ensure the node name of the consul agent is not and empty string", func(t *testing.T) {
+		node, err := DefaultAgent.NodeName(context.Background())
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(node) == 0 {
+			t.Error("bad empty node name returned for the consul agent")
+		}
+	})
+}

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,73 @@
+package consul
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Implementation of a non-blocking, temporary, cache for values of arbitrary
+// types.
+//
+// Instances of cachedValue are safe to use concurrently from multiple
+// goroutines.
+type cachedValue struct {
+	state atomic.Value
+	once  sync.Once
+}
+
+// Helper type for the cachedValue implementation.
+type cachedValueState struct {
+	lock     uint32
+	value    interface{}
+	error    error
+	expireAt time.Time
+}
+
+func (cache *cachedValue) lookup(now time.Time, exp time.Time, update func() (interface{}, error)) (interface{}, error) {
+	state := cache.load()
+
+	// A nil state indicate that the value has never been set yet, this is the
+	// only fully blocking situation since all goroutines must wait on the value
+	// to be initialized before they can read it.
+	if state == nil {
+		cache.once.Do(func() {
+			val, err := update()
+			cache.store(&cachedValueState{value: val, error: err, expireAt: exp})
+		})
+		state = cache.load()
+	}
+
+	// When the value has expired, only one goroutine will be in charge of
+	// fetching and setting an updated value, which is controlled by acquiring
+	// the atomic lock and doesn't block the concurrent execution of other
+	// goroutines.
+	if now.After(state.expireAt) {
+		if atomic.CompareAndSwapUint32(&state.lock, 0, 1) {
+			val, err := update()
+
+			// If an error occurred while trying to get an updated value we
+			// simply keep serving the previous value instead of discarding
+			// the cache.
+			//
+			// TODO: figure out how to report the error?
+			if err == nil {
+				state = &cachedValueState{value: val, error: err, expireAt: exp}
+				cache.store(state)
+			}
+
+			atomic.StoreUint32(&state.lock, 0)
+		}
+	}
+
+	return state.value, state.error
+}
+
+func (cache *cachedValue) load() *cachedValueState {
+	state, _ := cache.state.Load().(*cachedValueState)
+	return state
+}
+
+func (cache *cachedValue) store(state *cachedValueState) {
+	cache.state.Store(state)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -4,11 +4,20 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/segmentio/objconv/json"
 )
+
+func init() {
+	if os.Getenv("CIRCLE_PROJECT_USERNAME") != "" {
+		// Consul takes a while to start...
+		time.Sleep(10 * time.Second)
+	}
+}
 
 func TestClient(t *testing.T) {
 	tests := []struct {

--- a/coordinates.go
+++ b/coordinates.go
@@ -1,0 +1,125 @@
+package consul
+
+import (
+	"context"
+	"math"
+	"time"
+)
+
+// The Coordinates type represents network coordinates of nodes in a consul
+// system.
+//
+// More information can be found at:
+// https://www.consul.io/docs/internals/coordinates.html
+type Coordinates struct {
+	Adjustment float64
+	Error      float64
+	Height     float64
+	Vec        [8]float64
+}
+
+// Distance computes the approximate RTT between two Consul coordinates.
+//
+// The algorithm was taken from:
+// https://www.consul.io/docs/internals/coordinates.html#working-with-coordinates
+func Distance(a Coordinates, b Coordinates) time.Duration {
+	// Calculate the Euclidean distance plus the heights.
+	sumsq := 0.0
+	for i := 0; i < len(a.Vec); i++ {
+		diff := a.Vec[i] - b.Vec[i]
+		sumsq += diff * diff
+	}
+	rtt := math.Sqrt(sumsq) + a.Height + b.Height
+
+	// Apply the adjustment components, guarding against negatives.
+	adjusted := rtt + a.Adjustment + b.Adjustment
+	if adjusted > 0.0 {
+		rtt = adjusted
+	}
+
+	// Go's times are natively nanoseconds, so we convert from seconds.
+	const secondsToNanoseconds = 1.0e9
+	return time.Duration(rtt * secondsToNanoseconds)
+}
+
+// NodeCoordinates is a mapping of node names to their consul coordinates.
+type NodeCoordinates map[string]Coordinates
+
+// Distance computes the approximate RTT between two nodes of coords. The second
+// return value is true if both nodes existed in the map, false otherwise.
+func (coords NodeCoordinates) Distance(nodeA string, nodeB string) (time.Duration, bool) {
+	c1, ok1 := coords[nodeA]
+	c2, ok2 := coords[nodeB]
+	return Distance(c1, c2), ok1 && ok2
+}
+
+// Tomography exposes methods to fetch network coordinates information from
+// consul.
+//
+// The Tomography implementation uses an internal cache of node coordinates that
+// is updated asynchronously and fully non-blocking (except for the very first
+// call which has to initialize the cache).
+//
+// Methods of Tomography are safe to use concurrently from multiple goroutines,
+// assuming the fields aren't being modified after the value was constructed.
+type Tomography struct {
+	// The Client used to send requests to a consul agent.
+	Client *Client
+
+	// Configures how often the state is updated. If zero, the state is updated
+	// every second.
+	Timeout time.Duration
+
+	// Cached state of the consul network tomography.
+	nodes cachedValue
+}
+
+// NodeCoordinates returns the current coordinates of all nodes in the consul
+// datacenter.
+func (t *Tomography) NodeCoordinates(ctx context.Context) (NodeCoordinates, error) {
+	now := time.Now()
+	exp := now.Add(t.timeout())
+
+	val, err := t.nodes.lookup(now, exp, func() (interface{}, error) {
+		return t.client().nodeCoordinates(ctx)
+	})
+
+	nodes, _ := val.(NodeCoordinates)
+	return nodes, err
+}
+
+func (t *Tomography) client() *Client {
+	if client := t.Client; client != nil {
+		return client
+	}
+	return DefaultClient
+}
+
+func (t *Tomography) timeout() time.Duration {
+	if timeout := t.Timeout; timeout != 0 {
+		return timeout
+	}
+	return 1 * time.Second
+}
+
+// DefaultTomography is used as the default Tomography instance when
+var DefaultTomography = &Tomography{}
+
+func (c *Client) nodeCoordinates(ctx context.Context) (nodes NodeCoordinates, err error) {
+	var results []struct {
+		Node  string
+		Coord Coordinates
+	}
+
+	if err = c.Get(ctx, "/v1/coordinate/nodes", nil, &results); err != nil {
+		return
+	}
+
+	nodes = make(NodeCoordinates, len(results))
+
+	for _, res := range results {
+		nodes[res.Node] = res.Coord
+	}
+
+	return
+}

--- a/coordinates.go
+++ b/coordinates.go
@@ -68,7 +68,7 @@ type Tomography struct {
 
 	// Configures how often the state is updated. If zero, the state is updated
 	// every second.
-	Timeout time.Duration
+	CacheTimeout time.Duration
 
 	// Cached state of the consul network tomography.
 	nodes cachedValue
@@ -78,7 +78,7 @@ type Tomography struct {
 // datacenter.
 func (t *Tomography) NodeCoordinates(ctx context.Context) (NodeCoordinates, error) {
 	now := time.Now()
-	exp := now.Add(t.timeout())
+	exp := now.Add(t.cacheTimeout())
 
 	val, err := t.nodes.lookup(now, exp, func() (interface{}, error) {
 		return t.client().nodeCoordinates(ctx)
@@ -95,9 +95,9 @@ func (t *Tomography) client() *Client {
 	return DefaultClient
 }
 
-func (t *Tomography) timeout() time.Duration {
-	if timeout := t.Timeout; timeout != 0 {
-		return timeout
+func (t *Tomography) cacheTimeout() time.Duration {
+	if cacheTimeout := t.CacheTimeout; cacheTimeout != 0 {
+		return cacheTimeout
 	}
 	return 1 * time.Second
 }

--- a/coordinates_test.go
+++ b/coordinates_test.go
@@ -40,7 +40,7 @@ func TestTomography(t *testing.T) {
 
 	t.Run("exercise the node coordinates automatic update", func(t *testing.T) {
 		tomography := &Tomography{
-			Timeout: 10 * time.Millisecond,
+			CacheTimeout: 10 * time.Millisecond,
 		}
 
 		// The first call triggers the asynchronous automatic update.

--- a/coordinates_test.go
+++ b/coordinates_test.go
@@ -1,0 +1,95 @@
+package consul
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestTomography(t *testing.T) {
+	t.Run("fetching node coordinates return a non-empty set", func(t *testing.T) {
+		tomography := &Tomography{}
+
+		nodes1, err1 := tomography.NodeCoordinates(context.Background())
+		nodes2, err2 := tomography.NodeCoordinates(context.Background())
+
+		if err1 != nil {
+			t.Error("the first call to (*Tomography).NodeCoordinates returned an error:", err1)
+		}
+
+		if err2 != nil {
+			t.Error("the second call to (*Tomography).NodeCoordinates returned an error:", err2)
+		}
+
+		// Due to internal caching, two consecutive calls to NodeCoordinates
+		// should have returned the same map.
+		ptr1 := reflect.ValueOf(nodes1).Pointer()
+		ptr2 := reflect.ValueOf(nodes2).Pointer()
+
+		if ptr1 != ptr2 {
+			t.Error("the tomography cache should have returned the same NodeCoordinates value on two consecutive calls:")
+			t.Logf("%#v", nodes1)
+			t.Logf("%#v", nodes2)
+		}
+
+		if len(nodes1) == 0 {
+			t.Error("the tomography of the consul datacenter cannot be an empty set of node coordinates")
+		}
+	})
+
+	t.Run("exercise the node coordinates automatic update", func(t *testing.T) {
+		tomography := &Tomography{
+			Timeout: 10 * time.Millisecond,
+		}
+
+		// The first call triggers the asynchronous automatic update.
+		nodes1, err1 := tomography.NodeCoordinates(context.Background())
+
+		// Sleeping for a little while should given the autoupdate a chance to
+		// run and change the node map.
+		time.Sleep(30 * time.Millisecond)
+
+		// The second call should fetch a different value from the updated
+		// internal cache.
+		nodes2, err2 := tomography.NodeCoordinates(context.Background())
+
+		if err1 != nil {
+			t.Error("the first call to (*Tomography).NodeCoordinates returned an error:", err1)
+		}
+
+		if err2 != nil {
+			t.Error("the second call to (*Tomography).NodeCoordinates returned an error:", err2)
+		}
+
+		ptr1 := reflect.ValueOf(nodes1).Pointer()
+		ptr2 := reflect.ValueOf(nodes2).Pointer()
+
+		if ptr1 == ptr2 {
+			t.Error("the automatic updated of the tomography's internal cache should not have returned the same node coordinates value twice in a row")
+			t.Logf("%#v", nodes1)
+			t.Logf("%#v", nodes2)
+		}
+	})
+
+	t.Run("ensure the distance between nodes and itself is zero, or non-zero otherwise", func(t *testing.T) {
+		tomography := &Tomography{}
+		nodes, err := tomography.NodeCoordinates(context.Background())
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		for node1 := range nodes {
+			for node2 := range nodes {
+				distance, ok := nodes.Distance(node1, node2)
+				switch {
+				case !ok:
+					t.Errorf("the distance from %s to %s could not be computed", node1, node2)
+				case distance == 0:
+					t.Errorf("the distance from %s to %s should not be zero", node1, node2)
+				}
+			}
+		}
+	})
+}

--- a/coordinates_test.go
+++ b/coordinates_test.go
@@ -34,7 +34,7 @@ func TestTomography(t *testing.T) {
 		}
 
 		if len(nodes1) == 0 {
-			t.Error("the tomography of the consul datacenter cannot be an empty set of node coordinates")
+			t.Log("the tomography of the consul datacenter returned an empty set of node coordinates, likely because it was recently started and haven't computed the tomology yet")
 		}
 	})
 

--- a/dialer.go
+++ b/dialer.go
@@ -51,7 +51,7 @@ func (d *Dialer) DialContext(ctx context.Context, network string, address string
 		if len(addrs) == 0 {
 			return nil, fmt.Errorf("no addresses returned by the resolver for %s", host)
 		}
-		address = addrs[0].String()
+		address = addrs[0].Addr.String()
 	}
 
 	return (&net.Dialer{

--- a/endpoint.go
+++ b/endpoint.go
@@ -24,8 +24,9 @@ type Endpoint struct {
 	// running.
 	Meta map[string]string
 
-	// RTT is an estimation of the round-trip-time between the node specified in
-	// Resolver.Near and the endpoint (may be zero if Near wasn't set).
+	// RTT is an estimation of the round-trip-time between the node specified by
+	// Resolver.Agent and the endpoint (may be zero if the information wasn't yet
+	// available).
 	RTT time.Duration
 
 	// This field is used internally by the weighted shuffle algorithms,

--- a/endpoint.go
+++ b/endpoint.go
@@ -1,0 +1,98 @@
+package consul
+
+import (
+	"math"
+	"math/rand"
+	"net"
+	"sort"
+	"time"
+)
+
+// An Endpoint represents the address at which a service is available, coupled
+// with the metadata associated with the service registration.
+type Endpoint struct {
+	// The node name that the endpoint belongs to.
+	Node string
+
+	// The network address at which the service can be reached.
+	Addr net.Addr
+
+	// The list of tags associated with the service.
+	Tags []string
+
+	// The set of metadata associated with the node on which the service is
+	// running.
+	Meta map[string]string
+
+	// RTT is an estimation of the round-trip-time between the node specified in
+	// Resolver.Near and the endpoint (may be zero if Near wasn't set).
+	RTT time.Duration
+
+	// This field is used internally by the weighted shuffle algorithms,
+	// embedding it in the endpoint value itself makes the algorithm more
+	// efficient since it doesn't need to allocate a separate slice to do the
+	// shuffling and then map the results back to the endpoint list.
+	expWeight float64
+
+	// TODO: add health check information?
+}
+
+// Shuffle is a sorting function that randomly rearranges the list of endpoints.
+func Shuffle(list []Endpoint) {
+	for i := range list {
+		j := rand.Intn(i + 1)
+		list[i], list[j] = list[j], list[i]
+	}
+}
+
+// WeightedShuffleOnRTT is a sorting function that randomly rearranges the list
+// of endpoints, using the RTT as a weight to increase the chance of endpoints
+// with low RTT to be placed at the front of the list.
+func WeightedShuffleOnRTT(list []Endpoint) {
+	WeightedShuffle(list, func(endpoint Endpoint) float64 {
+		if endpoint.RTT != 0 {
+			return float64(endpoint.RTT)
+		}
+		// If the RTT information was not available there are typically three
+		// situations:
+		//
+		// - The coordinates were not available yet to do caching of the
+		// tomography information, in that case we're better off delaying
+		// traffic from reaching the endpoint until the tomography is updated.
+		//
+		// - There was an error getting the tomography information, this is very
+		// unlikely since it only needs to be fetched once (the cache is never
+		// expired if it can't be updated). In that case it's very likely that
+		// all endpoints will have a zero RTT and using a non-zero weight will
+		// help shuffle the list of endpoints.
+		//
+		// - The list of endpoints doesn't come from Resolver.LookupService and
+		// no RTT has been configured. Again, using a non-zero weight helps the
+		// weighted shuffled algorithm.
+		return math.MaxFloat64
+	})
+}
+
+// WeightedShuffle is a sorting function that randomly rearranges the list of
+// endpoints, using the weightOf function to obtain the weight of each endpoint
+// of the list.
+func WeightedShuffle(list []Endpoint, weightOf func(Endpoint) float64) {
+	for i := range list {
+		list[i].expWeight = weightOf(list[i]) * rand.ExpFloat64()
+	}
+	sort.Sort(byExpWeight(list))
+}
+
+type byExpWeight []Endpoint
+
+func (list byExpWeight) Len() int {
+	return len(list)
+}
+
+func (list byExpWeight) Less(i int, j int) bool {
+	return list[i].expWeight < list[j].expWeight
+}
+
+func (list byExpWeight) Swap(i int, j int) {
+	list[i], list[j] = list[j], list[i]
+}

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -1,0 +1,46 @@
+package consul
+
+import (
+	"math/rand"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestShuffle(t *testing.T) {
+	const N = 100
+
+	list1 := make([]Endpoint, N)
+	list2 := make([]Endpoint, N)
+
+	for i := 0; i != N; i++ {
+		list1[i].Node = strconv.Itoa(i)
+	}
+
+	copy(list2, list1)
+	Shuffle(list2)
+
+	if reflect.DeepEqual(list1, list2) {
+		t.Error("the shuffled service list did not differ from the original")
+	}
+}
+
+func TestWeightedShuffleOnRTT(t *testing.T) {
+	const N = 100
+
+	list1 := make([]Endpoint, N)
+	list2 := make([]Endpoint, N)
+
+	for i := 0; i != N; i++ {
+		list1[i].Node = strconv.Itoa(i)
+		list1[i].RTT = time.Duration(rand.Int63())
+	}
+
+	copy(list2, list1)
+	WeightedShuffleOnRTT(list2)
+
+	if reflect.DeepEqual(list1, list2) {
+		t.Error("the shuffled service list did not differ from the original")
+	}
+}

--- a/httpconsul/transport.go
+++ b/httpconsul/transport.go
@@ -52,7 +52,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if len(req.Host) == 0 {
 			req.Host = req.URL.Host
 		}
-		req.URL.Host = addrs[0].String()
+		req.URL.Host = addrs[0].Addr.String()
 	}
 	return t.base.RoundTrip(req)
 }

--- a/listener_test.go
+++ b/listener_test.go
@@ -4,17 +4,11 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 )
 
 func TestListener(t *testing.T) {
-	if os.Getenv("CIRCLE_PROJECT_USERNAME") != "" {
-		// Consul takes a while to start...
-		time.Sleep(10 * time.Second)
-	}
-
 	httpLstn, err := (&Listener{
 		ServiceName:                         "test-listener",
 		CheckHTTP:                           "/",

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -92,7 +92,7 @@ func TestResolverCache(t *testing.T) {
 
 		miss := int32(0)
 		cache := &ResolverCache{
-			Timeout: 10 * time.Millisecond,
+			CacheTimeout: 10 * time.Millisecond,
 		}
 
 		lookup := func(ctx context.Context, name string) (addrs []Endpoint, err error) {
@@ -124,7 +124,7 @@ func TestResolverCache(t *testing.T) {
 
 		miss := int32(0)
 		cache := &ResolverCache{
-			Timeout: 10 * time.Millisecond,
+			CacheTimeout: 10 * time.Millisecond,
 		}
 
 		lookup := func(ctx context.Context, name string) (addrs []Endpoint, err error) {


### PR DESCRIPTION
Hey guys, here's the implementation of the weighted shuffling logic for the list of service endpoints looked up on consul.

It depended on a few concepts:
- reading the consul tomography information (see the `consul.Agent` type)
- reading the consul agent configuration (see the `consul.Tomography` type)
- implementing a weighted shuffling algorithm (mostly did researched on the web for that)
- implementing the network distance computation algorithm based on network coordinates (which was given in the consul documentation)

Overall, nothing very innovative here, mostly just putting together nice abstractions that make this all easy to test and integrate.

Both `consul.Agent` and `consul.Tomography` expose very static information that can leverage caching, which is implemented in a shared `cachedValue` type to avoid having to write the same logic twice.

Shuffling of the service endpoint list is done by setting the `Resolver.Sort` function to `consul.WeightedShuffleOnRTT`. This can be bypassed if the field is set to `nil`, or customized if set to any other sorting function.

Please take a look and let me know if anything should be changed.