### PR TITLE
Store

### DIFF
--- a/client.go
+++ b/client.go
@@ -112,18 +112,12 @@ func (c *Client) Do(ctx context.Context, method string, path string, query Query
 	var req io.ReadCloser
 	var res io.ReadCloser
 
-	switch v := send.(type) {
-	case nil:
-	case io.ReadCloser:
-		req = v
-	case []byte:
-		req = ioutil.NopCloser(bytes.NewReader(v))
-	default:
-		var b []byte
-		if b, err = json.Marshal(v); err != nil {
+	if send != nil {
+		b := &bytes.Buffer{}
+		if err = json.NewEncoder(b).Encode(send); err != nil {
 			return
 		}
-		req = ioutil.NopCloser(bytes.NewReader(b))
+		req = ioutil.NopCloser(b)
 	}
 
 	if _, res, err = c.do(ctx, method, path, query, req); err != nil {

--- a/store.go
+++ b/store.go
@@ -134,13 +134,11 @@ func (store *Store) Write(ctx context.Context, key string, value io.ReadCloser, 
 
 	locks, _ := ctx.Value(LocksKey).([]string)
 	for _, lock := range locks {
-		if strings.HasPrefix(lock, store.Keyspace) {
-			if lock = store.clean(lock); lock == key {
-				query = append(query, Param{
-					Name:  "acquire",
-					Value: string(contextSession(ctx).ID),
-				})
-			}
+		if lock = store.clean(lock); lock == key {
+			query = append(query, Param{
+				Name:  "acquire",
+				Value: string(contextSession(ctx).ID),
+			})
 		}
 	}
 
@@ -210,9 +208,8 @@ func (store *Store) path(key string) string {
 }
 
 func (store *Store) clean(key string) string {
-	if key = key[len(store.Keyspace):]; len(key) != 0 && key[0] == '/' {
-		key = key[1:]
-	}
+	key = strings.TrimPrefix(key, store.Keyspace)
+	key = strings.TrimPrefix(key, "/")
 	return key
 }
 

--- a/store.go
+++ b/store.go
@@ -1,0 +1,221 @@
+package consul
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/segmentio/objconv"
+	"github.com/segmentio/objconv/json"
+)
+
+// A Store exposes an API to interract with the consul key/value store.
+type Store struct {
+	// The client used to send requests to the consul agent.
+	Client *Client
+
+	// A key prefix to apply to all operations made on this store.
+	Keyspace string
+}
+
+// Tree recursively scans the given key prefix in the consul key/value store,
+// returning the list of keys as a slice of strings.
+//
+// If the consul key/value store contains a large number of keys under the given
+// prefix, one may prefer to use the Walk method to iterate through the keys
+// without loading them all in memory.
+func (store *Store) Tree(ctx context.Context, prefix string) (keys []string, err error) {
+	err = store.client().Get(ctx, store.path(prefix), Query{{Name: "keys"}}, &keys)
+	for i := range keys {
+		keys[i] = store.clean(keys[i])
+	}
+	return
+}
+
+// Walk traverses the keyspace under the given prefix, calling the walk function
+// for each key.
+//
+// If the walk function returns an error the iteration is stopped and the error
+// is returned by Walk.
+func (store *Store) Walk(ctx context.Context, prefix string, walk func(key string) error) (err error) {
+	var result io.ReadCloser
+	var query = Query{
+		{Name: "keys"},
+		{Name: "recurse", Value: "true"},
+	}
+
+	if _, result, err = store.client().do(ctx, "GET", store.path(prefix), query, nil); err != nil {
+		return
+	}
+	defer result.Close()
+
+	var stream = json.NewStreamDecoder(result)
+	var key string
+
+	for stream.Decode(&key) == nil {
+		if err = walk(store.clean(key)); err != nil {
+			return
+		}
+	}
+
+	err = stream.Err()
+	return
+}
+
+// Read reads the value of the given key, returning it as a pair of an
+// io.ReadCloser and value of the last index that modified the key.
+//
+// The program must close the value when it's done reading from it to prevent
+// any leak of internal resources.
+func (store *Store) Read(ctx context.Context, key string) (value io.ReadCloser, index int64, err error) {
+	var header http.Header
+	var sindex string
+
+	if header, value, err = store.client().do(ctx, "GET", store.path(key), Query{{Name: "raw"}}, nil); err != nil {
+		return
+	}
+
+	if sindex = header.Get("X-Consul-Index"); len(sindex) == 0 {
+		value.Close()
+		err = errMissingXConsulIndex
+		return
+	}
+
+	if index, err = strconv.ParseInt(sindex, 10, 64); err != nil {
+		value.Close()
+		err = fmt.Errorf("bad X-Consul-Index in HTTP response: %s", sindex)
+		return
+	}
+
+	return
+}
+
+// ReadValue reads the JSON-encoded value at the given key into ptr. The usual
+// unmarshaling rules apply.
+//
+// See Read for more details on the method.
+func (store *Store) ReadValue(ctx context.Context, key string, ptr interface{}) (index int64, err error) {
+	var result io.ReadCloser
+
+	if result, index, err = store.Read(ctx, key); err != nil {
+		return
+	}
+	defer result.Close()
+
+	err = json.NewDecoder(result).Decode(ptr)
+	return
+}
+
+// Write writes bytes from value at the given key in the consul key/value store.
+//
+// If index is set to a positive value, it is used to turn the write call into a
+// compare-and-swap operation. The value will only be updated if the last index
+// that modified the key matches the given index.
+//
+// If the given context inherits from a lock, the associated session is used to
+// allow the write operation to succeed.
+//
+// The method returns a boolean that indicates whether the write operation
+// succeeded, it would return false if the key was locked by another session
+// or if index was specified but was different in consul.
+//
+// The value is always closed by a call to Write, even if the method returns an
+// error.
+func (store *Store) Write(ctx context.Context, key string, value io.ReadCloser, index int64) (ok bool, err error) {
+	var result io.ReadCloser
+	var query Query
+
+	locks, _ := ctx.Value(LocksKey).([]string)
+	for _, lock := range locks {
+		if strings.HasPrefix(lock, store.Keyspace) {
+			if lock = store.clean(lock); lock == key {
+				query = append(query, Param{
+					Name:  "acquire",
+					Value: string(contextSession(ctx).ID),
+				})
+			}
+		}
+	}
+
+	if index > 0 {
+		query = append(query, Param{
+			Name:  "cas",
+			Value: strconv.FormatInt(index, 10),
+		})
+	}
+
+	if _, result, err = store.client().do(ctx, "PUT", store.path(key), query, value); err != nil {
+		return
+	}
+	defer result.Close()
+
+	err = json.NewDecoder(result).Decode(&ok)
+	return
+}
+
+// WriteValue writes the JSON representation of value at the given key.
+// The usual marshaling rules apply.
+//
+// See Write for more details on the method.
+func (store *Store) WriteValue(ctx context.Context, key string, value interface{}, index int64) (ok bool, err error) {
+	// Use a pretty-JSON encoder to make it easier to read values in the consul
+	// web UI.
+	b := &bytes.Buffer{}
+	e := objconv.Encoder{Emitter: json.NewPrettyEmitter(b)}
+
+	if err = e.Encode(value); err != nil {
+		return
+	}
+
+	ok, err = store.Write(ctx, key, ioutil.NopCloser(b), index)
+	return
+}
+
+// Delete deletes the keys stored under the given prefix. If index is set to a
+// positive value, it is used to turn the delete call into a compare-and-swap
+// operation where the keys are only deleted if the last index that modified
+// them matches the given index.
+//
+// The method returns a boolean to indicate whether the keys could be deleted.
+func (store *Store) Delete(ctx context.Context, prefix string, index int64) (ok bool, err error) {
+	query := Query{{"recurse", "true"}}
+
+	if index > 0 {
+		query = append(query, Param{
+			Name:  "cas",
+			Value: strconv.FormatInt(index, 10),
+		})
+	}
+
+	err = store.client().Delete(ctx, store.path(prefix), query, &ok)
+	return
+}
+
+func (store *Store) client() *Client {
+	if client := store.Client; client != nil {
+		return client
+	}
+	return DefaultClient
+}
+
+func (store *Store) path(key string) string {
+	return path.Join("/v1/kv", store.Keyspace, key)
+}
+
+func (store *Store) clean(key string) string {
+	if key = key[len(store.Keyspace):]; len(key) != 0 && key[0] == '/' {
+		key = key[1:]
+	}
+	return key
+}
+
+var (
+	errMissingXConsulIndex = errors.New("missing X-Consul-Index in HTTP response")
+)

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,220 @@
+package consul
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestStore(t *testing.T) {
+	tests := []struct {
+		scenario string
+		test     func(*testing.T, context.Context, *Store)
+	}{
+		{
+			scenario: "write a couple of keys and ensure they show up when listing the key/value store",
+			test:     testWriteAndTree,
+		},
+
+		{
+			scenario: "write a couple of keys and ensure they show up when walking the key/value store",
+			test:     testWriteAndWalk,
+		},
+
+		{
+			scenario: "write a key and verify that reading the value returns the right content",
+			test:     testWriteAndRead,
+		},
+
+		{
+			scenario: "compare-and-swap a value must fail if the last modification index differs",
+			test:     testCompareAndSwapFailure,
+		},
+
+		{
+			scenario: "compare-and-swap a value must succeed if the last modification index matches",
+			test:     testCompareAndSwapSuccess,
+		},
+
+		{
+			scenario: "writing a locked key without passing the lock context should fail",
+			test:     testWriteLockedKeyFailure,
+		},
+
+		{
+			scenario: "writing a locked key while passing the lock context should succeed",
+			test:     testWriteLockedKeySuccess,
+		},
+	}
+
+	counter := int32(0)
+
+	for _, test := range tests {
+		testFunc := test.test
+		t.Run(test.scenario, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			store := &Store{
+				Keyspace: fmt.Sprintf("test-store-%d", atomic.AddInt32(&counter, 1)),
+			}
+
+			defer func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+				defer cancel()
+
+				if ok, err := store.Delete(ctx, "", -1); err != nil {
+					t.Error(err)
+				} else if !ok {
+					t.Error("failed to delete test keyspace", store.Keyspace)
+				}
+			}()
+			testFunc(t, ctx, store)
+		})
+	}
+}
+
+func testWriteAndTree(t *testing.T, ctx context.Context, store *Store) {
+	keys := []string{"A/1", "A/2", "B/1", "C/1", "A/3"}
+
+	for i, key := range keys {
+		write(t, ctx, store, key, i, -1)
+	}
+
+	tree, err := store.Tree(ctx, "A")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(tree, []string{"A/1", "A/2", "A/3"}) {
+		t.Error("bad keys:", tree)
+	}
+}
+
+func testWriteAndWalk(t *testing.T, ctx context.Context, store *Store) {
+	keys := []string{"A/1", "A/2", "B/1", "C/1", "A/3"}
+
+	for i, key := range keys {
+		write(t, ctx, store, key, i, -1)
+	}
+
+	i := 0
+	ref := []string{"A/1", "A/2", "A/3"}
+	err := store.Walk(ctx, "A", func(key string) error {
+		if key != ref[i] {
+			return fmt.Errorf("bad key at index %d: %q != %q", i, key, ref[i])
+		}
+		i++
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+}
+
+func testWriteAndRead(t *testing.T, ctx context.Context, store *Store) {
+	type T struct {
+		Hello  string
+		Answer int
+	}
+
+	v1 := T{"World", 42}
+	v2 := T{}
+	write(t, ctx, store, "my-key", v1, -1)
+
+	if _, err := store.ReadValue(ctx, "my-key", &v2); err != nil {
+		t.Error("reading my-key failed:", err)
+	}
+
+	if !reflect.DeepEqual(v1, v2) {
+		t.Error("readin my-key returned an bad value:")
+		t.Logf("<<< %#v", v1)
+		t.Logf(">>> %#v", v2)
+	}
+}
+
+func testCompareAndSwapFailure(t *testing.T, ctx context.Context, store *Store) {
+	write(t, ctx, store, "A", 42, -1)
+
+	value := int(0)
+	index, err := store.ReadValue(ctx, "A", &value)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Updating the key will change the last modification index.
+	write(t, ctx, store, "A", 1, -1)
+
+	// Attempting a compare-and-swap should fail.
+	if ok, err := store.WriteValue(ctx, "A", 2, index); err != nil {
+		t.Error(err)
+	} else if ok {
+		t.Error("the CAS operation should have failed because the last modification index has been changed")
+	}
+}
+
+func testCompareAndSwapSuccess(t *testing.T, ctx context.Context, store *Store) {
+	write(t, ctx, store, "A", 42, -1)
+
+	value := int(0)
+	index, err := store.ReadValue(ctx, "A", &value)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Attempting a compare-and-swap should succeed because the key hasn't been
+	// modified.
+	write(t, ctx, store, "A", 1, index)
+
+	if _, err := store.ReadValue(ctx, "A", &value); err != nil {
+		t.Error(err)
+	} else if value != 1 {
+		t.Error("bad value after CAS operation:", value)
+	}
+}
+
+func testWriteLockedKeyFailure(t *testing.T, ctx context.Context, store *Store) {
+	_, unlock := (&Locker{Client: store.Client}).Lock(ctx, store.Keyspace+"/A")
+	defer unlock()
+
+	session, expire := WithSession(ctx, Session{})
+	defer expire()
+	// Build a context that pretends to be a lock on A from a different session.
+	ctx = context.WithValue(session, LocksKey, []string{store.Keyspace + "/A"})
+
+	// Attempting to write the keys without passing the session holding the lock
+	// should fail.
+	if ok, err := store.WriteValue(ctx, "A", 2, -1); err != nil {
+		t.Error(err)
+	} else if ok {
+		t.Error("the write operation passed the wrong lock as context therefore it should have failed")
+	}
+}
+
+func testWriteLockedKeySuccess(t *testing.T, ctx context.Context, store *Store) {
+	lock, unlock := (&Locker{Client: store.Client}).Lock(ctx, "A")
+	defer unlock()
+
+	// Passing the lock should allow the key to be written.
+	if ok, err := store.WriteValue(lock, "A", 2, -1); err != nil {
+		t.Error(err)
+	} else if !ok {
+		t.Error("the write operation passed the lock as context therefore it should have succeeded")
+	}
+}
+
+func write(t *testing.T, ctx context.Context, store *Store, key string, value interface{}, index int64) {
+	if ok, err := store.WriteValue(ctx, key, value, index); err != nil {
+		t.Fatalf("writing %s=%v failed (%s)", key, value, err)
+	} else if !ok {
+		t.Fatalf("writing %s=%v failed (WriteValue returned false)", key, value)
+	}
+}

--- a/store_test.go
+++ b/store_test.go
@@ -182,7 +182,7 @@ func testCompareAndSwapSuccess(t *testing.T, ctx context.Context, store *Store) 
 }
 
 func testWriteLockedKeyFailure(t *testing.T, ctx context.Context, store *Store) {
-	_, unlock := (&Locker{Client: store.Client}).Lock(ctx, store.Keyspace+"/A")
+	_, unlock := (&Locker{Client: store.Client, Keyspace: store.Keyspace}).Lock(ctx, "A")
 	defer unlock()
 
 	session, expire := WithSession(ctx, Session{})
@@ -200,7 +200,7 @@ func testWriteLockedKeyFailure(t *testing.T, ctx context.Context, store *Store) 
 }
 
 func testWriteLockedKeySuccess(t *testing.T, ctx context.Context, store *Store) {
-	lock, unlock := (&Locker{Client: store.Client}).Lock(ctx, "A")
+	lock, unlock := (&Locker{Client: store.Client, Keyspace: store.Keyspace}).Lock(ctx, "A")
 	defer unlock()
 
 	// Passing the lock should allow the key to be written.


### PR DESCRIPTION
Hey guys, here are the basic building blocks to interface with the Consul key/value store.

I've had to modify a bit of the HTTP client implementation implementation to expose an `io.Reader` based that allows values to be efficiently streamed in and out of Consul.

On top of the byte-stream API I've added the `(*Store).ReadValue` and `(*Store).WriteValue` methods which automatically marshal/unmarshal JSON values because I believe this would likely be the most common use case.

There are a couple of tests that test basic functionalities and other trickier parts of the implementation (compare-and-swap operations, locking).

Follow up work would probably include adding a caching layer for read operations to make accesses to the store more efficient, as well as exposing an API to manipulate the `Flags` property of the store entries.

Please take a look and let me know if anything should be changed.