### PR TITLE
detect lock loss

### DIFF
--- a/locker.go
+++ b/locker.go
@@ -260,7 +260,7 @@ func (l *lockCtx) run(session Session) {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(l, timeout)
 		sid, err := l.client.fetchLock(ctx, l.key)
 		cancel()
 

--- a/session.go
+++ b/session.go
@@ -183,15 +183,7 @@ func (s *sessionCtx) id() string {
 }
 
 func (s *sessionCtx) run() {
-	// Pick the shortest of the TTL or the LockDelay to compute the session
-	// renewal interval. This ensures that any locks depending on it will
-	// be notified that the session was lost before the lock delay expires.
-	timeout := s.session.TTL
-	if s.session.LockDelay < s.session.TTL {
-		timeout = s.session.LockDelay
-	}
-	timeout /= 3
-
+	timeout := s.session.TTL / 3
 	ticker := time.NewTicker(timeout)
 	defer ticker.Stop()
 


### PR DESCRIPTION
This PR modifies the lock implementation to ensure that it detects lock losses due to external causes (like an operator releasing a lock explicitly). The code previously only relied on checking that the parent session was active, which is fine when everything works _as expected_ but can break when we start messing around with the system.

Please take a look and let me know if something should be changed.