### PR TITLE
better choose which network address gets registered to consul

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -268,8 +268,8 @@ func findIPAddr(iface net.Interface) (net.IP, error) {
 	}
 
 	// Prefer IPv4 because consul has issues with making TCP health checks to
-	// IPv6 addresses. If we haven't found an v4 address it's very likely that
-	// the health checks won't pass with an v6 address but at least the code is
+	// IPv6 addresses. If we haven't found a v4 address it's very likely that
+	// the health checks won't pass with a v6 address but at least the code is
 	// future proof is the program gets resolved.
 	if ipv4 != nil {
 		return ipv4, nil

--- a/listener.go
+++ b/listener.go
@@ -222,7 +222,7 @@ func publicOrLoopbackIP() (net.IP, error) {
 
 	for _, iface := range ifaces {
 		if (iface.Flags&net.FlagUp) != 0 && (iface.Flags&(net.FlagLoopback|net.FlagPointToPoint)) == 0 {
-			if a, e := findIPAddr(iface); e != nil {
+			if a, e := findIP(iface); e != nil {
 				err = e
 			} else if a != nil {
 				return a, nil
@@ -232,7 +232,7 @@ func publicOrLoopbackIP() (net.IP, error) {
 
 	for _, iface := range ifaces {
 		if (iface.Flags & net.FlagLoopback) != 0 {
-			if a, e := findIPAddr(iface); e != nil {
+			if a, e := findIP(iface); e != nil {
 				err = e
 			} else if a != nil {
 				return a, nil
@@ -247,7 +247,7 @@ func publicOrLoopbackIP() (net.IP, error) {
 	return nil, err
 }
 
-func findIPAddr(iface net.Interface) (net.IP, error) {
+func findIP(iface net.Interface) (net.IP, error) {
 	addrs, err := iface.Addrs()
 
 	if err != nil {

--- a/listener.go
+++ b/listener.go
@@ -2,11 +2,14 @@ package consul
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -77,7 +80,6 @@ func (l *Listener) ListenContext(ctx context.Context, network string, address st
 		Name:              l.ServiceName,
 		Tags:              l.ServiceTags,
 		EnableTagOverride: l.ServiceEnableTagOverride,
-		Address:           lstn.Addr().String(),
 	}
 
 	if service.Name == "" {
@@ -90,11 +92,36 @@ func (l *Listener) ListenContext(ctx context.Context, network string, address st
 
 	if l.ServiceAddress != nil {
 		service.Address = l.ServiceAddress.String()
+		addr, port, _ := net.SplitHostPort(service.Address)
+		service.Address = addr
+		service.Port, err = strconv.Atoi(port)
+
+		if err != nil {
+			err = fmt.Errorf("bad port number in network address %s://%s", network, address)
+		}
+
+	} else {
+		switch addr := lstn.Addr().(type) {
+		case *net.TCPAddr:
+			zeroIPv4 := net.ParseIP("0.0.0.0")
+			zeroIPv6 := net.ParseIP("::")
+
+			if addr.IP.Equal(zeroIPv4) || addr.IP.Equal(zeroIPv6) {
+				addr.IP, err = publicOrLoopbackIP()
+				addr.Zone = ""
+			}
+
+			service.Address = addr.IP.String()
+			service.Port = addr.Port
+		default:
+			service.Address = addr.String()
+		}
 	}
 
-	addr, port, _ := net.SplitHostPort(service.Address)
-	service.Address = addr
-	service.Port, _ = strconv.Atoi(port)
+	if err != nil {
+		lstn.Close()
+		return nil, err
+	}
 
 	service.Checks = []checkConfig{{
 		Notes:    "Ensure consul can establish TCP connections to the service",
@@ -182,4 +209,71 @@ func Listen(network string, address string) (net.Listener, error) {
 // The context may be used to asynchronously cancel the consul registration.
 func ListenContext(ctx context.Context, network string, address string) (net.Listener, error) {
 	return (&Listener{}).ListenContext(ctx, network, address)
+}
+
+func publicOrLoopbackIP() (net.IP, error) {
+	var ifaces []net.Interface
+	var err error
+
+	if ifaces, err = net.Interfaces(); err != nil {
+		return nil, err
+	}
+	sort.Slice(ifaces, func(i int, j int) bool { return ifaces[i].Index < ifaces[i].Index })
+
+	for _, iface := range ifaces {
+		if (iface.Flags&net.FlagUp) != 0 && (iface.Flags&(net.FlagLoopback|net.FlagPointToPoint)) == 0 {
+			if a, e := findIPAddr(iface); e != nil {
+				err = e
+			} else if a != nil {
+				return a, nil
+			}
+		}
+	}
+
+	for _, iface := range ifaces {
+		if (iface.Flags & net.FlagLoopback) != 0 {
+			if a, e := findIPAddr(iface); e != nil {
+				err = e
+			} else if a != nil {
+				return a, nil
+			}
+		}
+	}
+
+	if err == nil {
+		err = errors.New("no network interfaces were found")
+	}
+
+	return nil, err
+}
+
+func findIPAddr(iface net.Interface) (net.IP, error) {
+	addrs, err := iface.Addrs()
+
+	if err != nil {
+		return nil, err
+	}
+
+	var ipv4 net.IP
+	var ipv6 net.IP
+
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok {
+			if ipnet.IP.To4() != nil {
+				ipv4 = ipnet.IP
+			} else {
+				ipv6 = ipnet.IP
+			}
+		}
+	}
+
+	// Prefer IPv4 because consul has issues with making TCP health checks to
+	// IPv6 addresses. If we haven't found an v4 address it's very likely that
+	// the health checks won't pass with an v6 address but at least the code is
+	// future proof is the program gets resolved.
+	if ipv4 != nil {
+		return ipv4, nil
+	}
+
+	return ipv6, nil
 }


### PR DESCRIPTION
The intent of this change is to make consul registration work as intuitively expected when _listening on all interfaces_ with an address like `0.0.0.0`, `[::]`, or `:0`.

Without this change, the service would register the zeroed address to consul, which of course would fail the health check because it doesn't instruct consul to connect to anything.

The new behavior is to detect when the listener is waiting to listen on all addresses, and register the address of the first public network interface, or fallback to the address of the loopback interface.

The reason why we're looking for a non-loopback address first is to maximize the chances of consul being able to reach the service, for example if it's running in a container it wouldn't be able to connect through the loopback interface.

Here's a screenshot from the test I ran to verify the behavior:
![screen shot 2017-06-02 at 4 12 51 pm](https://cloud.githubusercontent.com/assets/865510/26748164/2cb80166-47b0-11e7-983b-0a27bc7921f2.png)

Please take a look and let me know if something should be changed.