### PR TITLE
add consul.(*Resolver).LookupHost

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -60,6 +60,27 @@ type Resolver struct {
 	Sort func([]Endpoint)
 }
 
+// LookupHost resolves a service name to a list of network addresses.
+//
+// The method name is a bit misleading because it uses the term Host but accepts
+// a service name as argument, this is done to match the signature of the
+// net.(*Resolver).LookupHost method so the types can satisfy the same interface.
+func (rslv *Resolver) LookupHost(ctx context.Context, name string) ([]string, error) {
+	endpoints, err := rslv.LookupService(ctx, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := make([]string, len(endpoints))
+
+	for i, endpoint := range endpoints {
+		addrs[i] = endpoint.Addr.String()
+	}
+
+	return addrs, nil
+}
+
 // LookupService resolves a service name to a list of endpoints using the
 // resolver's configuration to narrow and sort the result set.
 func (rslv *Resolver) LookupService(ctx context.Context, name string) ([]Endpoint, error) {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -80,6 +80,67 @@ func testLookupService(t *testing.T, cache *ResolverCache) {
 	}
 }
 
+func testLookupHost(t *testing.T, cache *ResolverCache) {
+	server, client := newServerClient(func(res http.ResponseWriter, req *http.Request) {
+		if req.Method != "GET" {
+			t.Error("bad method:", req.Method)
+		}
+
+		if req.URL.Path != "/v1/health/service/1234" {
+			t.Error("bad URL path:", req.URL.Path)
+		}
+
+		foundQuery := req.URL.Query()
+		expectQuery := url.Values{
+			"passing":   {""},
+			"dc":        {"dc1"},
+			"tag":       {"A", "B", "C"},
+			"node-meta": {"answer:42"},
+		}
+		if !reflect.DeepEqual(foundQuery, expectQuery) {
+			t.Error("bad URL query:")
+			t.Logf("expected: %#v", expectQuery)
+			t.Logf("found:    %#v", foundQuery)
+		}
+
+		type service struct {
+			Address string
+			Port    int
+		}
+		json.NewEncoder(res).Encode([]struct {
+			Service service
+		}{
+			{Service: service{Address: "192.168.0.1", Port: 4242}},
+			{Service: service{Address: "192.168.0.2", Port: 4242}},
+			{Service: service{Address: "192.168.0.3", Port: 4242}},
+		})
+		return
+	})
+	defer server.Close()
+
+	rslv := Resolver{
+		Client:      client,
+		ServiceTags: []string{"A", "B", "C"},
+		NodeMeta:    map[string]string{"answer": "42"},
+		OnlyPassing: true,
+		Cache:       cache,
+	}
+
+	addrs, err := rslv.LookupHost(context.Background(), "1234")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(addrs, []string{
+		"192.168.0.1:4242",
+		"192.168.0.2:4242",
+		"192.168.0.3:4242",
+	}) {
+		t.Error("bad addresses returned:", addrs)
+	}
+}
+
 func TestResolverCache(t *testing.T) {
 	list := []Endpoint{
 		{Addr: &serviceAddr{"192.168.0.1", 4242}},


### PR DESCRIPTION
The main intent here is to be able to inject a consul-based resolver in the kafka dialer => https://github.com/segmentio/kafka-go/blob/master/dialer.go#L57
