### PR TITLE
Lookup by ID

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -11,6 +11,9 @@ import (
 // An Endpoint represents the address at which a service is available, coupled
 // with the metadata associated with the service registration.
 type Endpoint struct {
+	// The ID under which the service was registered.
+	ID string
+
 	// The node name that the endpoint belongs to.
 	Node string
 

--- a/listener.go
+++ b/listener.go
@@ -84,11 +84,11 @@ func (l *Listener) ListenContext(ctx context.Context, network string, address st
 		EnableTagOverride: l.ServiceEnableTagOverride,
 	}
 
-	if service.Name == "" {
+	if len(service.Name) == 0 {
 		service.Name = filepath.Base(os.Args[0])
 	}
 
-	if service.ID == "" {
+	if len(service.ID) == 0 {
 		service.ID = service.Name
 	} else {
 		service.ID = service.Name + ":" + service.ID
@@ -134,7 +134,7 @@ func (l *Listener) ListenContext(ctx context.Context, network string, address st
 		TCP:      net.JoinHostPort(service.Address, strconv.Itoa(service.Port)),
 	}}
 
-	if l.CheckHTTP != "" {
+	if len(l.CheckHTTP) != 0 {
 		service.Checks = append(service.Checks, checkConfig{
 			Notes:    "Ensure consul can submit HTTP requests to the service",
 			Interval: "10s",

--- a/listener.go
+++ b/listener.go
@@ -25,6 +25,8 @@ type Listener struct {
 	// A unique identifier for the service registered to consul. This only needs
 	// to be unique within the agent that the service registers to, and may be
 	// omitted. In that case, ServiceName is used instead.
+	// This value is appended to ServiceName using ':' as separator to create a
+	// unique ID for the listener within a set of services with the same name.
 	ServiceID string
 
 	// The logical name of the service registered to consul. If none is set, the
@@ -88,6 +90,8 @@ func (l *Listener) ListenContext(ctx context.Context, network string, address st
 
 	if service.ID == "" {
 		service.ID = service.Name
+	} else {
+		service.ID = service.Name + ":" + service.ID
 	}
 
 	if l.ServiceAddress != nil {


### PR DESCRIPTION
This PR adds the ability to resolve services by ID. The problem it solves is that the `/v1/health/service/:service` endpoint doesn't support looking up services by ID, only by name.

The changes here allow passing names to `(*Resolver).LookupService` which are made of the service name and service ID, separated by a `:`. The resolver still look up services by name but filters out the result list of endpoints to only expose one that matches the given ID (or none).

Please take a look and let me know if anything should be changed.