### PR TITLE
longer timeouts

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,8 +39,8 @@ var (
 		MaxIdleConnsPerHost:   2,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   5 * time.Second,
-		ResponseHeaderTimeout: 1 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 5 * time.Second,
+		ExpectContinueTimeout: 5 * time.Second,
 	}
 
 	// DefaultClient is the default client used when none is specified.


### PR DESCRIPTION
I noticed some timeouts on requests to consul for session TTL extension, I assume consul needs to forward those requests to the remote servers which if there's a packet loss on a new TCP connections would mean it'll have to wait 3 seconds before resending the SYN. This PR extends the timeout to 5 seconds to work around those cases.