### PR TITLE
Balancer

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -174,8 +174,6 @@ type Rotator struct {
 
 // Balance satisfies the Balancer interface.
 func (rr *Rotator) Balance(name string, endpoints []Endpoint) []Endpoint {
-	rotated := endpoints
-
 	n := len(endpoints)
 	i := int(atomic.AddUint64(&rr.offset, 1) % uint64(n))
 
@@ -183,7 +181,7 @@ func (rr *Rotator) Balance(name string, endpoints []Endpoint) []Endpoint {
 		rotate(endpoints, i)
 	}
 
-	return rotated
+	return endpoints
 }
 
 func rotate(endpoints []Endpoint, d int) {

--- a/balancer.go
+++ b/balancer.go
@@ -157,7 +157,7 @@ func (rr *RoundRobin) Balance(name string, endpoints []Endpoint) []Endpoint {
 }
 
 func rotate(endpoints []Endpoint, d int) {
-	reverse(endpoints[:d-1])
+	reverse(endpoints[:d])
 	reverse(endpoints[d:])
 	reverse(endpoints)
 }

--- a/balancer.go
+++ b/balancer.go
@@ -256,3 +256,32 @@ func PreferEC2AvailabilityZone() (Balancer, error) {
 
 	return PreferTags{string(b)}, nil
 }
+
+// Shuffler is a Balancer implementation which returns a randomly shuffled list
+// of endpoints.
+type Shuffler struct{}
+
+// Balance satsifies the Balancer interface.
+func (*Shuffler) Balance(name string, endpoints []Endpoint) []Endpoint {
+	Shuffle(endpoints)
+	return endpoints
+}
+
+// WeightedShuffler is a Balancer implementation which shuffles the list of
+// endpoints using a different weight for each endpoint.
+type WeightedShuffler struct {
+	// WeightOf returns the weight of an endpoint.
+	WeightOf func(Endpoint) float64
+}
+
+// Balance satisfies the Balancer interface.
+func (ws *WeightedShuffler) Balance(name string, endpoints []Endpoint) []Endpoint {
+	weightOf := ws.WeightOf
+
+	if weightOf == nil {
+		weightOf = func(_ Endpoint) float64 { return 1.0 }
+	}
+
+	WeightedShuffle(endpoints, weightOf)
+	return endpoints
+}

--- a/balancer.go
+++ b/balancer.go
@@ -94,6 +94,9 @@ func (lb *LoadBalancer) Balance(name string, endpoints []Endpoint) []Endpoint {
 			version:  version,
 		}
 		lb.mutex.Lock()
+		if lb.services == nil {
+			lb.services = make(map[string]*loadBalancerEntry)
+		}
 		// Don't re-check if the service already exists, worst case we reset the
 		// balancer for that service which is fine, in most case it'll make the
 		// synchronized section a bit shorter.

--- a/balancer.go
+++ b/balancer.go
@@ -119,11 +119,11 @@ func (lb *LoadBalancer) cleanup(version uint64) {
 	lb.mutex.RLock()
 
 	for name, entry := range lb.services {
-		if (entry.version - version) > loadBalancerCleanupInterval {
+		if diffU64(version, entry.version) > loadBalancerCleanupInterval {
 			lb.mutex.RUnlock() // wish there was a way to promote to a write-lock
 			lb.mutex.Lock()
 
-			if (entry.version - version) > loadBalancerCleanupInterval {
+			if diffU64(version, entry.version) > loadBalancerCleanupInterval {
 				delete(lb.services, name)
 			}
 
@@ -133,6 +133,13 @@ func (lb *LoadBalancer) cleanup(version uint64) {
 	}
 
 	lb.mutex.RUnlock()
+}
+
+func diffU64(high uint64, low uint64) uint64 {
+	if high < low {
+		return 0
+	}
+	return high - low
 }
 
 // RoundRobin is the implementation of a simple load balancing algorithms which

--- a/balancer.go
+++ b/balancer.go
@@ -4,9 +4,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // Balancer is the interface implemented by types that provides load balancing
@@ -74,36 +74,6 @@ type LoadBalancer struct {
 	version  uint64
 	cleaning uint64
 	services map[string]*loadBalancerEntry
-}
-
-// NewLoadBalancer creates and returns a new instance of LoadBalancer which
-// reorders the list of service endpoints using the list of algorithms passed
-// as arguments. Valid balancing algorithm names are "round-robin",
-// "prefer-ec2-zone", "shuffle", and "weighted-shuffle-on-rtt", or any other
-// algorithm which has been registered in the Balancers map. Invalid names
-// are ignored, if there are no valid algorithms then round robin is used.
-func NewLoadBalancer(algorithms ...string) *LoadBalancer {
-	constructors := make([](func() Balancer), 0, len(algorithms))
-
-	for _, a := range algorithms {
-		if c, ok := Balancers[a]; ok {
-			constructors = append(constructors, c)
-		}
-	}
-
-	if len(constructors) == 0 {
-		constructors = append(constructors, func() Balancer { return &RoundRobin{} })
-	}
-
-	return &LoadBalancer{
-		New: func() Balancer {
-			balancers := make([]Balancer, len(constructors))
-			for i, constructor := range constructors {
-				balancers[i] = constructor()
-			}
-			return MultiBalancer(balancers...)
-		},
-	}
 }
 
 type loadBalancerEntry struct {
@@ -279,23 +249,29 @@ func containsTag(tags []string, tag string) bool {
 // PreferEC2AvailabilityZone is a constructor for a balancer which prefers
 // routing traffic to services registered in the same EC2 availability zone
 // than the caller.
-func PreferEC2AvailabilityZone() (Balancer, error) {
-	c := &http.Client{
-		Transport: DefaultClient.Transport,
+//
+// If the metadata aren't available the function returns the NullBalancer
+// balancer which doesn't modify the list of endpoints.
+func PreferEC2AvailabilityZone(c *http.Client) Balancer {
+	if c == nil {
+		c = &http.Client{
+			Timeout:   5 * time.Second,
+			Transport: DefaultClient.Transport,
+		}
 	}
 
 	r, err := c.Get("http://169.254.169.254/latest/meta-data/placement/availability-zone")
 	if err != nil {
-		return nil, err
+		return &NullBalancer{}
 	}
 	defer r.Body.Close()
 
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return nil, err
+		return &NullBalancer{}
 	}
 
-	return PreferTags{string(b)}, nil
+	return PreferTags{string(b)}
 }
 
 // Shuffler is a Balancer implementation which returns a randomly shuffled list
@@ -327,39 +303,19 @@ func (ws *WeightedShuffler) Balance(name string, endpoints []Endpoint) []Endpoin
 	return endpoints
 }
 
-// Balancers is a map of load balancing algorithm names to constructors.
-// By default it contains the algorithms defined in this package, but programs
-// may modify this map to change the list of algorithms supported by the
-// NewLoadBalancer function.
-var Balancers = map[string](func() Balancer){
-	"round-robin": func() Balancer {
-		return &RoundRobin{}
-	},
+// NullBalancer is a balancer which doesn't modify the list of endpoints.
+type NullBalancer struct{}
 
-	"prefer-ec2-zone": func() Balancer {
-		b, err := PreferEC2AvailabilityZone()
-		if err != nil {
-			b = BalancerFunc(func(_ string, e []Endpoint) []Endpoint { return e })
-		}
-		return b
-	},
-
-	"shuffle": func() Balancer {
-		return &Shuffler{}
-	},
-
-	"weighted-shuffle-on-rtt": func() Balancer {
-		return &WeightedShuffler{WeightOf: WeightRTT}
-	},
+// Balance satisfies the Balancer interface.
+func (*NullBalancer) Balance(name string, endpoints []Endpoint) []Endpoint {
+	return endpoints
 }
 
-// DefaultBalancer is the balancer used by the default resolver. The balancer
-// is configured based on the value of the CONSUL_LOAD_BALANCER environment
-// variable which is expected to be set to a '+' separated list of load balancer
-// names.
-//
-// If CONSUL_LOAD_BALANCER isn't set the default balancer uses a simple
-// round-robin algorithm.
-//
-// Refer to the NewLoadBalancer documentation for a list of valid names.
-var DefaultBalancer Balancer = NewLoadBalancer(strings.Split(os.Getenv("CONSUL_LOAD_BALANCER"), "+")...)
+func defaultCacheBalancer() Balancer {
+	switch os.Getenv("CONSUL_CACHE_BALANCER") {
+	case "ec2-zone-affinity":
+		return PreferEC2AvailabilityZone(nil)
+	default:
+		return &NullBalancer{}
+	}
+}

--- a/balancer.go
+++ b/balancer.go
@@ -164,7 +164,7 @@ func (lb *LoadBalancer) cleanup(version uint64) {
 			}
 
 			lb.mutex.Unlock()
-			lb.mutex.RUnlock()
+			lb.mutex.RLock()
 		}
 	}
 

--- a/balancer.go
+++ b/balancer.go
@@ -359,7 +359,7 @@ var Balancers = map[string](func() Balancer){
 // names.
 //
 // If CONSUL_LOAD_BALANCER isn't set the default balancer uses a simple
-// round-robinn algorithm.
+// round-robin algorithm.
 //
 // Refer to the NewLoadBalancer documentation for a list of valid names.
 var DefaultBalancer Balancer = NewLoadBalancer(strings.Split(os.Getenv("CONSUL_LOAD_BALANCER"), "+")...)

--- a/balancer.go
+++ b/balancer.go
@@ -1,0 +1,258 @@
+package consul
+
+import (
+	"io/ioutil"
+	"math"
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// Balancer is the interface implemented by types that provides load balancing
+// algorithms for a Resolver.
+//
+// Balancers must be safe to use concurrently from multiple goroutines.
+type Balancer interface {
+	// Balance is called with a service name and a list of endpoints that this
+	// name resolved to, and returns the potentially modified list of endpoints
+	// sorted by preference.
+	//
+	// The returned slice of endpoints may or may not be the same slice than the
+	// one that was passed to the method, the balancer implementation is allowed
+	// to perform in-place modifications of the endpoints slice, applications
+	// must take into consideration that the balancer ownes the slice for the
+	// duration of the method call.
+	//
+	// Balance must not retain the slice of endpoints it received, nor the one
+	// it returned.
+	Balance(name string, endpoints []Endpoint) []Endpoint
+}
+
+// BalancerFunc allows regular functions to be used as balancers.
+type BalancerFunc func(string, []Endpoint) []Endpoint
+
+// Balance calls f, satisfies the Balancer interface.
+func (f BalancerFunc) Balance(name string, endpoints []Endpoint) []Endpoint {
+	return f(name, endpoints)
+}
+
+// MultiBalancer composes a new Balancer from a list of multiple balancers, each
+// of them being called for each Balance call in the order that they were given
+// to the function.
+func MultiBalancer(balancers ...Balancer) Balancer {
+	multi := make([]Balancer, len(balancers))
+	copy(multi, balancers)
+	return &multiBalancer{balancers: multi}
+}
+
+type multiBalancer struct {
+	balancers []Balancer
+}
+
+func (m *multiBalancer) Balance(name string, endpoints []Endpoint) []Endpoint {
+	for _, b := range m.balancers {
+		endpoints = b.Balance(name, endpoints)
+	}
+	return endpoints
+}
+
+// A LoadBalancer is an implementation of Balancer which maintains a set of
+// balancers that are local to each service name that Balance has been called
+// for.
+// It enables using simple load balancing algorithms that are designed to work
+// on a set of endpoints belonging to a single service (like RoundRobin) in the
+// context of the Resolver which may be used to
+type LoadBalancer struct {
+	New func() Balancer
+
+	mutex    sync.RWMutex
+	version  uint32
+	cleaning uint32
+	services map[string]*loadBalancerEntry
+}
+
+type loadBalancerEntry struct {
+	Balancer
+	version uint32
+}
+
+const (
+	loadBalancerCleanupInterval = 1000
+)
+
+// Balance satisfies the Balancer interface.
+func (lb *LoadBalancer) Balance(name string, endpoints []Endpoint) []Endpoint {
+	version := atomic.AddUint32(&lb.version, 1)
+
+	lb.mutex.RLock()
+	entry := lb.services[name]
+	lb.mutex.RUnlock()
+
+	if entry == nil {
+		entry = &loadBalancerEntry{
+			Balancer: lb.New(),
+			version:  version,
+		}
+		lb.mutex.Lock()
+		// Don't re-check if the service already exists, worst case we reset the
+		// balancer for that service which is fine, in most case it'll make the
+		// synchronized section a bit shorter.
+		lb.services[name] = entry
+		lb.mutex.Unlock()
+	}
+
+	endpoints = entry.Balance(name, endpoints)
+
+	if (version % loadBalancerCleanupInterval) == 0 {
+		if atomic.CompareAndSwapUint32(&lb.cleaning, 0, 1) {
+			lb.cleanup(version)
+			atomic.StoreUint32(&lb.cleaning, 0)
+		}
+	}
+
+	return endpoints
+}
+
+func (lb *LoadBalancer) cleanup(version uint32) {
+	lb.mutex.RLock()
+
+	for name, entry := range lb.services {
+		if diffU32(version, entry.version) > loadBalancerCleanupInterval {
+			lb.mutex.RUnlock() // wish there was a way to promote to a write-lock
+			lb.mutex.Lock()
+
+			if diffU32(version, entry.version) > loadBalancerCleanupInterval {
+				delete(lb.services, name)
+			}
+
+			lb.mutex.Unlock()
+			lb.mutex.RUnlock()
+		}
+	}
+
+	lb.mutex.RUnlock()
+}
+
+func diffU32(high uint32, low uint32) uint32 {
+	if high < low {
+		return (math.MaxUint32 - high) + low
+	}
+	return high - low
+}
+
+// RoundRobin is the implementation of a simple load balancing algorithms which
+// reorders the slice of endpoints passed to its Balance method in a round robin
+// fashion.
+type RoundRobin struct {
+	offset uint32
+}
+
+// Balance satisfies the Balancer interface.
+func (rr *RoundRobin) Balance(name string, endpoints []Endpoint) []Endpoint {
+	rotated := endpoints
+
+	n := len(endpoints)
+	i := int(atomic.AddUint32(&rr.offset, 1)) % n
+
+	if i != 0 {
+		rotate(endpoints, i)
+	}
+
+	return rotated
+}
+
+func rotate(endpoints []Endpoint, d int) {
+	reverse(endpoints[:d-1])
+	reverse(endpoints[d:])
+	reverse(endpoints)
+}
+
+func reverse(endpoints []Endpoint) {
+	i := 0
+	j := len(endpoints) - 1
+
+	for i < j {
+		swap(endpoints, i, j)
+		i++
+		j--
+	}
+}
+
+func swap(endpoints []Endpoint, i int, j int) {
+	endpoints[i], endpoints[j] = endpoints[j], endpoints[i]
+}
+
+// PreferTags is a balancer which groups endpoints that match certain tags.
+// The tags are ordered by preference, so endpoints matching the tag at index
+// zero will be placed at the head of the result list.
+//
+// The result slice is also truncated to return only endpoints that matched at
+// least one tag, unless this would end up returning an empty slice, in which
+// case the balancer simply returns the full endpoints list.
+type PreferTags []string
+
+// Balance satisfies the Balancer interface.
+func (tags PreferTags) Balance(name string, endpoints []Endpoint) []Endpoint {
+	i := 0
+	n := len(endpoints)
+
+	for _, tag := range tags {
+		j := 0
+
+		for i < n {
+			if containsTag(endpoints[i].Tags, tag) {
+				i++
+				continue
+			}
+
+			if j <= i {
+				j = i + 1
+			}
+
+			for j < n && !containsTag(endpoints[j].Tags, tag) {
+				j++
+			}
+
+			if j == n {
+				break
+			}
+
+			swap(endpoints, i, j)
+			j++
+			i++
+		}
+	}
+
+	if i == 0 {
+		i = n
+	}
+
+	return endpoints[:i]
+}
+
+func containsTag(tags []string, tag string) bool {
+	for _, candidate := range tags {
+		if candidate == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// PreferEC2AvailabilityZone is a constructor for a balancer which prefers
+// routing traffic to services registered in the same EC2 availability zone
+// than the caller.
+func PreferEC2AvailabilityZone() (Balancer, error) {
+	r, err := http.Get("http://169.254.169.254/latest/meta-data/placement/availability-zone")
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return PreferTags{string(b)}, nil
+}

--- a/balancer.go
+++ b/balancer.go
@@ -256,7 +256,6 @@ func (tags PreferTags) Balance(name string, endpoints []Endpoint) []Endpoint {
 			}
 
 			swap(endpoints, i, j)
-			j++
 			i++
 		}
 	}

--- a/balancer.go
+++ b/balancer.go
@@ -147,7 +147,7 @@ func (rr *RoundRobin) Balance(name string, endpoints []Endpoint) []Endpoint {
 	rotated := endpoints
 
 	n := len(endpoints)
-	i := int(atomic.AddUint64(&rr.offset, 1)) % n
+	i := int(atomic.AddUint64(&rr.offset, 1) % uint64(n))
 
 	if i != 0 {
 		rotate(endpoints, i)

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -1,0 +1,91 @@
+package consul
+
+import (
+	"sort"
+	"testing"
+)
+
+var balancers = []struct {
+	name string
+	impl Balancer
+}{
+	{
+		name: "RoundRobin",
+		impl: &RoundRobin{},
+	},
+
+	{
+		name: "PreferTags",
+		impl: PreferTags{"us-west-2a"},
+	},
+
+	{
+		name: "PreferTags+RoundRobin",
+		impl: MultiBalancer(
+			PreferTags{"us-west-2a"},
+			&RoundRobin{},
+		),
+	},
+}
+
+func TestBalancer(t *testing.T) {
+	for _, balancer := range balancers {
+		t.Run(balancer.name, func(t *testing.T) {
+			testBalancer(t, balancer.impl)
+		})
+	}
+}
+
+func testBalancer(t *testing.T, balancer Balancer) {
+	const endpointsCount = 30
+	const draws = 200
+
+	type counter struct {
+		index int
+		value int
+	}
+
+	base := generateTestEndpoints(endpointsCount)
+	counters := make([]counter, endpointsCount)
+	for i := range counters {
+		counters[i].index = i
+	}
+
+	endpoints := make([]Endpoint, endpointsCount)
+	for i := 0; i != draws; i++ {
+		copy(endpoints, base)
+		endpoints = balancer.Balance("test-service", endpoints)
+
+		for i := range base {
+			if endpoints[0].ID == base[i].ID {
+				counters[i].value++
+				break
+			}
+		}
+	}
+
+	sort.Slice(counters, func(i int, j int) bool {
+		return counters[i].value > counters[j].value
+	})
+
+	for _, c := range counters {
+		endpoint := base[c.index]
+		t.Logf("ID = %  s, RTT = % 5s: % 3d\t(%g%%)", endpoint.ID, endpoint.RTT, c.value, float64(c.value)*100.0/draws)
+	}
+}
+
+func BenchmarkBalancer(b *testing.B) {
+	for _, balancer := range balancers {
+		b.Run(balancer.name, func(b *testing.B) {
+			benchmarkBalancer(b, balancer.impl)
+		})
+	}
+}
+
+func benchmarkBalancer(b *testing.B, balancer Balancer) {
+	endpoints := generateTestEndpoints(300)
+
+	for i := 0; i != b.N; i++ {
+		balancer.Balance("service-A", endpoints)
+	}
+}

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -15,8 +15,13 @@ var balancers = []struct {
 	},
 
 	{
-		name: "PreferTags",
+		name: "PreferTags(us-west-2a)",
 		new:  func() Balancer { return PreferTags{"us-west-2a"} },
+	},
+
+	{
+		name: "PreferTags(us-west-2b)",
+		new:  func() Balancer { return PreferTags{"us-west-2b"} },
 	},
 
 	{

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -85,10 +85,10 @@ func testBalancer(t *testing.T, balancer Balancer) {
 	endpoints := make([]Endpoint, endpointsCount)
 	for i := 0; i != draws; i++ {
 		copy(endpoints, base)
-		endpoints = balancer.Balance("test-service", endpoints)
+		balanced := balancer.Balance("test-service", endpoints)
 
 		for i := range base {
-			if endpoints[0].ID == base[i].ID {
+			if balanced[0].ID == base[i].ID {
 				counters[i].value++
 				break
 			}

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -10,6 +10,11 @@ var balancers = []struct {
 	new  func() Balancer
 }{
 	{
+		name: "NullBalancer",
+		new:  func() Balancer { return &NullBalancer{} },
+	},
+
+	{
 		name: "RoundRobin",
 		new:  func() Balancer { return &RoundRobin{} },
 	},
@@ -50,17 +55,7 @@ var balancers = []struct {
 
 	{
 		name: "LoadBlancer+RoundRobin",
-		new:  func() Balancer { return NewLoadBalancer("round-robin") },
-	},
-
-	{
-		name: "LoadBlancer+Shuffler",
-		new:  func() Balancer { return NewLoadBalancer("shuffle") },
-	},
-
-	{
-		name: "LoadBlancer+WeightedShufflerOnRTT",
-		new:  func() Balancer { return NewLoadBalancer("weighted-shuffle-on-rtt") },
+		new:  func() Balancer { return &LoadBalancer{New: func() Balancer { return &RoundRobin{} }} },
 	},
 }
 

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -83,7 +83,7 @@ func testBalancer(t *testing.T, balancer Balancer) {
 
 	for _, c := range counters {
 		endpoint := base[c.index]
-		t.Logf("ID = %  s, RTT = % 5s: % 3d\t(%g%%)", endpoint.ID, endpoint.RTT, c.value, float64(c.value)*100.0/draws)
+		t.Logf("ID = %  s, RTT = % 5s, Tags = %s: % 3d\t(%g%%)", endpoint.ID, endpoint.RTT, endpoint.Tags, c.value, float64(c.value)*100.0/draws)
 	}
 }
 

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -20,6 +20,11 @@ var balancers = []struct {
 	},
 
 	{
+		name: "Rotator",
+		new:  func() Balancer { return &Rotator{} },
+	},
+
+	{
 		name: "PreferTags(us-west-2a)",
 		new:  func() Balancer { return PreferTags{"us-west-2a"} },
 	},

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -26,6 +26,20 @@ var balancers = []struct {
 			&RoundRobin{},
 		),
 	},
+
+	{
+		name: "Shuffler",
+		impl: &Shuffler{},
+	},
+
+	{
+		name: "WeightedShufflerOnRTT",
+		impl: &WeightedShuffler{
+			WeightOf: func(e Endpoint) float64 {
+				return float64(e.RTT)
+			},
+		},
+	},
 }
 
 func TestBalancer(t *testing.T) {

--- a/endpoint.go
+++ b/endpoint.go
@@ -58,28 +58,7 @@ func Shuffle(list []Endpoint) {
 // of endpoints, using the RTT as a weight to increase the chance of endpoints
 // with low RTT to be placed at the front of the list.
 func WeightedShuffleOnRTT(list []Endpoint) {
-	WeightedShuffle(list, func(endpoint Endpoint) float64 {
-		if endpoint.RTT != 0 {
-			return float64(endpoint.RTT)
-		}
-		// If the RTT information was not available there are typically three
-		// situations:
-		//
-		// - The coordinates were not available yet to do caching of the
-		// tomography information, in that case we're better off delaying
-		// traffic from reaching the endpoint until the tomography is updated.
-		//
-		// - There was an error getting the tomography information, this is very
-		// unlikely since it only needs to be fetched once (the cache is never
-		// expired if it can't be updated). In that case it's very likely that
-		// all endpoints will have a zero RTT and using a non-zero weight will
-		// help shuffle the list of endpoints.
-		//
-		// - The list of endpoints doesn't come from Resolver.LookupService and
-		// no RTT has been configured. Again, using a non-zero weight helps the
-		// weighted shuffled algorithm.
-		return math.MaxFloat64
-	})
+	WeightedShuffle(list, WeightRTT)
 }
 
 // WeightedShuffle is a sorting function that randomly rearranges the list of
@@ -94,6 +73,30 @@ func WeightedShuffle(list []Endpoint, weightOf func(Endpoint) float64) {
 
 	sort.Sort(byExpWeight(list))
 	randers.Put(rng)
+}
+
+// WeightRTT returns the weight of the given endpoint based on it's RTT value.
+func WeightRTT(endpoint Endpoint) float64 {
+	if endpoint.RTT != 0 {
+		return float64(endpoint.RTT)
+	}
+	// If the RTT information was not available there are typically three
+	// situations:
+	//
+	// - The coordinates were not available yet to do caching of the
+	// tomography information, in that case we're better off delaying
+	// traffic from reaching the endpoint until the tomography is updated.
+	//
+	// - There was an error getting the tomography information, this is very
+	// unlikely since it only needs to be fetched once (the cache is never
+	// expired if it can't be updated). In that case it's very likely that
+	// all endpoints will have a zero RTT and using a non-zero weight will
+	// help shuffle the list of endpoints.
+	//
+	// - The list of endpoints doesn't come from Resolver.LookupService and
+	// no RTT has been configured. Again, using a non-zero weight helps the
+	// weighted shuffled algorithm.
+	return math.MaxFloat64
 }
 
 type byExpWeight []Endpoint

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -85,7 +85,7 @@ func testDistribution(t *testing.T, shuffle func([]Endpoint)) {
 
 	for _, c := range counters {
 		endpoint := base[c.index]
-		t.Logf("ID = %  s, RTT = % 5s: % 3d\t(%g%%)", endpoint.ID, endpoint.RTT, c.value, float64(c.value)*100.0/draws)
+		t.Logf("ID = %  s, RTT = % 5s, Tags = %s: % 3d\t(%g%%)", endpoint.ID, endpoint.RTT, endpoint.Tags, c.value, float64(c.value)*100.0/draws)
 	}
 }
 

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"math/rand"
 	"reflect"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -43,4 +44,67 @@ func TestWeightedShuffleOnRTT(t *testing.T) {
 	if reflect.DeepEqual(list1, list2) {
 		t.Error("the shuffled service list did not differ from the original")
 	}
+}
+
+func TestDistribution(t *testing.T) {
+	t.Run("Shuffle", func(t *testing.T) { testDistribution(t, Shuffle) })
+	t.Run("WeightedShuffleOnRTT", func(t *testing.T) { testDistribution(t, WeightedShuffleOnRTT) })
+}
+
+func testDistribution(t *testing.T, shuffle func([]Endpoint)) {
+	const endpointsCount = 30
+	const draws = 200
+
+	type counter struct {
+		index int
+		value int
+	}
+
+	base := generateTestEndpoints(endpointsCount)
+	counters := make([]counter, endpointsCount)
+	for i := range counters {
+		counters[i].index = i
+	}
+
+	endpoints := make([]Endpoint, endpointsCount)
+	for i := 0; i != draws; i++ {
+		copy(endpoints, base)
+		shuffle(endpoints)
+
+		for i := range base {
+			if endpoints[0].ID == base[i].ID {
+				counters[i].value++
+				break
+			}
+		}
+	}
+
+	sort.Slice(counters, func(i int, j int) bool {
+		return counters[i].value > counters[j].value
+	})
+
+	for _, c := range counters {
+		endpoint := base[c.index]
+		t.Logf("ID = %  s, RTT = % 5s: % 3d\t(%g%%)", endpoint.ID, endpoint.RTT, c.value, float64(c.value)*100.0/draws)
+	}
+}
+
+func generateTestEndpoints(n int) []Endpoint {
+	endpoints := make([]Endpoint, n)
+	rtt := 200 * time.Microsecond
+	tag := "us-west-2a"
+
+	for i := 0; i != n; i++ {
+		endpoints[i].ID = strconv.Itoa(i)
+		endpoints[i].RTT = rtt
+		endpoints[i].Tags = []string{tag}
+		rtt += 10 * time.Microsecond
+
+		if i == (n / 2) {
+			rtt += time.Millisecond
+			tag = "us-west-2b"
+		}
+	}
+
+	return endpoints
 }

--- a/resolver.go
+++ b/resolver.go
@@ -232,6 +232,7 @@ func (rslv *Resolver) tomography() *Tomography {
 var DefaultResolver = &Resolver{
 	OnlyPassing: true,
 	Blacklist:   &ResolverBlacklist{},
+	Balancer:    DefaultBalancer,
 	Sort:        WeightedShuffleOnRTT,
 }
 

--- a/resolver.go
+++ b/resolver.go
@@ -69,6 +69,8 @@ type Resolver struct {
 	// of endpoints, otherwise consecutive calls would likely return the list in
 	// the same order, and picking the first item would result in routing all
 	// traffic to a single instance of the service.
+	//
+	// DEPRECATED: use Balancer instead.
 	Sort func([]Endpoint)
 }
 


### PR DESCRIPTION
This pull requests revisits the way we're doing load balancing and enhance the API with a couple more load balancing algorithms that should provide a more fair distribution than the weighted random based on the network RTT.

One combination that gave pretty nice results is filtering based on tags + doing round robin on the result:
```
    --- PASS: TestBalancer/PreferTags+RoundRobin (0.00s)
    	balancer_test.go:86: ID = 8, RTT = 280µs, Tags = [us-west-2a]:  13	(6.5%)
    	balancer_test.go:86: ID = 1, RTT = 210µs, Tags = [us-west-2a]:  13	(6.5%)
    	balancer_test.go:86: ID = 2, RTT = 220µs, Tags = [us-west-2a]:  13	(6.5%)
    	balancer_test.go:86: ID = 3, RTT = 230µs, Tags = [us-west-2a]:  13	(6.5%)
    	balancer_test.go:86: ID = 4, RTT = 240µs, Tags = [us-west-2a]:  13	(6.5%)
    	balancer_test.go:86: ID = 5, RTT = 250µs, Tags = [us-west-2a]:  13	(6.5%)
    	balancer_test.go:86: ID = 6, RTT = 260µs, Tags = [us-west-2a]:  13	(6.5%)
    	balancer_test.go:86: ID = 7, RTT = 270µs, Tags = [us-west-2a]:  13	(6.5%)
    	balancer_test.go:86: ID = 15, RTT = 350µs, Tags = [us-west-2a]:  12	(6%)
    	balancer_test.go:86: ID = 9, RTT = 290µs, Tags = [us-west-2a]:  12	(6%)
    	balancer_test.go:86: ID = 10, RTT = 300µs, Tags = [us-west-2a]:  12	(6%)
    	balancer_test.go:86: ID = 11, RTT = 310µs, Tags = [us-west-2a]:  12	(6%)
    	balancer_test.go:86: ID = 12, RTT = 320µs, Tags = [us-west-2a]:  12	(6%)
    	balancer_test.go:86: ID = 13, RTT = 330µs, Tags = [us-west-2a]:  12	(6%)
    	balancer_test.go:86: ID = 14, RTT = 340µs, Tags = [us-west-2a]:  12	(6%)
    	balancer_test.go:86: ID = 0, RTT = 200µs, Tags = [us-west-2a]:  12	(6%)
    	balancer_test.go:86: ID = 16, RTT = 1.36ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 17, RTT = 1.37ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 18, RTT = 1.38ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 19, RTT = 1.39ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 20, RTT = 1.4ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 21, RTT = 1.41ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 22, RTT = 1.42ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 23, RTT = 1.43ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 24, RTT = 1.44ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 25, RTT = 1.45ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 26, RTT = 1.46ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 27, RTT = 1.47ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 28, RTT = 1.48ms, Tags = [us-west-2b]:   0	(0%)
    	balancer_test.go:86: ID = 29, RTT = 1.49ms, Tags = [us-west-2b]:   0	(0%)
```

Another nice upside is the new algorithms are about 10x faster than using the ones based on random shuffling:
```
BenchmarkBalancer/RoundRobin-4         	  500000	      3076 ns/op	       0 B/op	       0 allocs/op
BenchmarkBalancer/PreferTags-4         	  500000	      2767 ns/op	       0 B/op	       0 allocs/op
BenchmarkBalancer/PreferTags+RoundRobin-4         	  300000	      4538 ns/op	       0 B/op	       0 allocs/op
BenchmarkBalancer/Shuffler-4                      	  100000	     11185 ns/op	       0 B/op	       0 allocs/op
BenchmarkBalancer/WeightedShufflerOnRTT-4         	   30000	     45796 ns/op	      33 B/op	       1 allocs/op
```

Please take a look and let me know if you have any questions.