### PR TITLE
add ResolverBlacklist

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -74,7 +74,7 @@ func (d *Dialer) DialContext(ctx context.Context, network string, address string
 		conn, err := dialer.DialContext(ctx, network, address)
 
 		if err != nil && attempt < 10 && resolver.Blacklist != nil {
-			resolver.Blacklist.Blacklist(addrs[0].Addr.String(), time.Now().Add(d.blacklistTTL()))
+			resolver.Blacklist.Blacklist(addrs[0].Addr, time.Now().Add(d.blacklistTTL()))
 			attempt++
 			continue
 		}

--- a/dialer.go
+++ b/dialer.go
@@ -24,6 +24,7 @@ type Dialer struct {
 	DualStack     bool
 	FallbackDelay time.Duration
 	KeepAlive     time.Duration
+	BlacklistTTL  time.Duration
 	Resolver      *Resolver
 }
 
@@ -43,8 +44,26 @@ func (d *Dialer) Dial(network string, address string) (net.Conn, error) {
 // (*net.Dialer).Dialcontext documentation at
 // https://golang.org/pkg/net/#Dialer.DialContext.
 func (d *Dialer) DialContext(ctx context.Context, network string, address string) (net.Conn, error) {
-	if host, _ := splitHostPort(address); len(host) != 0 && net.ParseIP(host) == nil {
-		addrs, err := d.resolver().LookupService(ctx, host)
+	host, _ := splitHostPort(address)
+	resolve := len(host) != 0 && net.ParseIP(host) == nil
+	attempt := 0
+
+	resolver := d.resolver()
+	dialer := &net.Dialer{
+		Timeout:       d.Timeout,
+		Deadline:      d.Deadline,
+		LocalAddr:     d.LocalAddr,
+		DualStack:     d.DualStack,
+		FallbackDelay: d.FallbackDelay,
+		KeepAlive:     d.KeepAlive,
+	}
+
+	if !resolve {
+		return dialer.DialContext(ctx, network, address)
+	}
+
+	for {
+		addrs, err := resolver.LookupService(ctx, host)
 		if err != nil {
 			return nil, err
 		}
@@ -52,16 +71,16 @@ func (d *Dialer) DialContext(ctx context.Context, network string, address string
 			return nil, fmt.Errorf("no addresses returned by the resolver for %s", host)
 		}
 		address = addrs[0].Addr.String()
-	}
+		conn, err := dialer.DialContext(ctx, network, address)
 
-	return (&net.Dialer{
-		Timeout:       d.Timeout,
-		Deadline:      d.Deadline,
-		LocalAddr:     d.LocalAddr,
-		DualStack:     d.DualStack,
-		FallbackDelay: d.FallbackDelay,
-		KeepAlive:     d.KeepAlive,
-	}).DialContext(ctx, network, address)
+		if err != nil && attempt < 10 && resolver.Blacklist != nil {
+			resolver.Blacklist.Blacklist(addrs[0].Addr.String(), time.Now().Add(d.blacklistTTL()))
+			attempt++
+			continue
+		}
+
+		return conn, err
+	}
 }
 
 func (d *Dialer) resolver() *Resolver {
@@ -69,6 +88,13 @@ func (d *Dialer) resolver() *Resolver {
 		return rslv
 	}
 	return DefaultResolver
+}
+
+func (d *Dialer) blacklistTTL() time.Duration {
+	if ttl := d.BlacklistTTL; ttl != 0 {
+		return ttl
+	}
+	return 1 * time.Second
 }
 
 // Dial is a wrapper for calling (*Dialer).Dial on a default dialer.

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -7,11 +7,20 @@ import (
 	"net/url"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/segmentio/objconv/json"
 )
 
 func TestDialer(t *testing.T) {
+	t.Run("dialing existing services results in a connection being established to one of the endpoints",
+		testDialerDialExistingService)
+
+	t.Run("dialing non-existing services results in blacklisting the endpoints and an error after a couple of attempts",
+		testDialerDialNonExistingService)
+}
+
+func testDialerDialExistingService(t *testing.T) {
 	httpServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.Write([]byte("Hello World!"))
 	}))
@@ -50,6 +59,37 @@ func TestDialer(t *testing.T) {
 
 	if s := string(b); s != "Hello World!" {
 		t.Error("bad response:", s)
+	}
+}
+
+func testDialerDialNonExistingService(t *testing.T) {
+	consulServer, consulClient := newServerClient(func(res http.ResponseWriter, req *http.Request) {
+		type service struct {
+			Address string
+			Port    int
+		}
+		json.NewEncoder(res).Encode([]struct{ Service service }{{Service: service{"192.0.2.0", 42}}})
+	})
+	defer consulServer.Close()
+
+	// The HTTP client uses a transport with a resolver that uses consul to
+	// lookup service addresses.
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&Dialer{
+				Timeout: 10 * time.Millisecond,
+				Resolver: &Resolver{
+					Client:    consulClient,
+					Blacklist: &ResolverBlacklist{},
+				},
+			}).DialContext,
+		},
+	}
+
+	res, err := httpClient.Get("http://whatever/")
+	if err == nil {
+		res.Body.Close()
+		t.Error("no error returned when sending a request to an invalid address")
 	}
 }
 

--- a/httpconsul/transport.go
+++ b/httpconsul/transport.go
@@ -66,7 +66,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		if err != nil && attempt < 10 && t.rslv.Blacklist != nil && isIdempotent(req.Method) {
 			// TODO: make the blacklist TTL configurable here?
-			t.rslv.Blacklist.Blacklist(addrs[0].Addr.String(), time.Now().Add(1*time.Second))
+			t.rslv.Blacklist.Blacklist(addrs[0].Addr, time.Now().Add(1*time.Second))
 			attempt++
 			continue
 		}

--- a/httpconsul/transport_test.go
+++ b/httpconsul/transport_test.go
@@ -3,16 +3,26 @@ package httpconsul
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"testing"
+	"time"
 
 	consul "github.com/segmentio/consul-go"
 )
 
-func TestResolver(t *testing.T) {
+func TestTransport(t *testing.T) {
+	t.Run("sending requests to existing services results in a getting a response from one of the endpoints",
+		testTransportRequestExistingService)
+
+	t.Run("sending requests to non-existing services results in blacklisting the endpoints and an error after a couple of attempts",
+		testTransportRequestNonExistingService)
+}
+
+func testTransportRequestExistingService(t *testing.T) {
 	httpServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.Write([]byte("Hello World!"))
 	}))
@@ -47,6 +57,39 @@ func TestResolver(t *testing.T) {
 
 	if s := string(b); s != "Hello World!" {
 		t.Error("bad response:", s)
+	}
+}
+
+func testTransportRequestNonExistingService(t *testing.T) {
+	consulServer, consulClient := newServerClient(func(res http.ResponseWriter, req *http.Request) {
+		type service struct {
+			Address string
+			Port    int
+		}
+		json.NewEncoder(res).Encode([]struct{ Service service }{{Service: service{"192.0.2.0", 42}}})
+	})
+	defer consulServer.Close()
+
+	// The HTTP client uses a transport with a resolver that uses consul to
+	// lookup service addresses.
+	httpClient := &http.Client{
+		Transport: NewTransportWith(
+			&http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout: 10 * time.Millisecond,
+				}).DialContext,
+			},
+			&consul.Resolver{
+				Client:    consulClient,
+				Blacklist: &consul.ResolverBlacklist{},
+			},
+		),
+	}
+
+	res, err := httpClient.Get("http://whatever/")
+	if err == nil {
+		res.Body.Close()
+		t.Error("no error returned when sending a request to an invalid address")
 	}
 }
 

--- a/resolver.go
+++ b/resolver.go
@@ -443,12 +443,13 @@ const (
 )
 
 // Blacklist adds a blacklisted address, which expires and expireAt is reached.
-func (blacklist *ResolverBlacklist) Blacklist(addr string, expireAt time.Time) {
+func (blacklist *ResolverBlacklist) Blacklist(addr net.Addr, expireAt time.Time) {
+	key := addr.String()
 	blacklist.mutex.Lock()
 	if blacklist.addrs == nil {
 		blacklist.addrs = make(map[string]time.Time)
 	}
-	blacklist.addrs[addr] = expireAt
+	blacklist.addrs[key] = expireAt
 	blacklist.mutex.Unlock()
 }
 

--- a/resolver.go
+++ b/resolver.go
@@ -42,6 +42,10 @@ type Resolver struct {
 	// OnlyPassing fields.
 	Cache *ResolverCache
 
+	// This field may be set to allow the resolver to support temporarily
+	// blacklisting addresses that are known to be unreachable.
+	Blacklist *ResolverBlacklist
+
 	// Agent is used to set the origin from which the distance to each endpoints
 	// are computed. If nil, DefaultAgent is used instead.
 	Agent *Agent
@@ -98,6 +102,10 @@ func (rslv *Resolver) LookupService(ctx context.Context, name string) ([]Endpoin
 
 	if err != nil {
 		return nil, err
+	}
+
+	if rslv.Blacklist != nil {
+		list = rslv.Blacklist.Filter(list, time.Now())
 	}
 
 	if rslv.Sort != nil {
@@ -166,11 +174,8 @@ func (rslv *Resolver) lookupService(ctx context.Context, name string) (list []En
 
 	for i, res := range results {
 		list[i] = Endpoint{
-			ID: res.Service.ID,
-			Addr: &serviceAddr{
-				addr: res.Service.Address,
-				port: res.Service.Port,
-			},
+			ID:   res.Service.ID,
+			Addr: newServiceAddr(res.Service.Address, res.Service.Port),
 			Tags: res.Service.Tags,
 			Node: res.Node.Node,
 			Meta: res.Node.Meta,
@@ -224,18 +229,14 @@ func LookupService(ctx context.Context, name string) ([]Endpoint, error) {
 	return DefaultResolver.LookupService(ctx, name)
 }
 
-type serviceAddr struct {
-	addr string
-	port int
+type serviceAddr string
+
+func newServiceAddr(host string, port int) serviceAddr {
+	return serviceAddr(net.JoinHostPort(host, strconv.Itoa(port)))
 }
 
-func (a *serviceAddr) Network() string {
-	return ""
-}
-
-func (a *serviceAddr) String() string {
-	return net.JoinHostPort(a.addr, strconv.Itoa(a.port))
-}
+func (serviceAddr) Network() string  { return "" }
+func (a serviceAddr) String() string { return string(a) }
 
 // LookupServiceFunc is the signature of functions that can be used to lookup
 // service names.
@@ -423,4 +424,85 @@ func splitNameID(s string) (name string, id string) {
 		name, id = s[:i], s[i+1:]
 	}
 	return
+}
+
+// ResolverBlacklist implements a negative caching for Resolver instances.
+// It works by registering addresses that should be filtered out of a service
+// name resolution result, with a deadline at which the address blacklist will
+// expire.
+type ResolverBlacklist struct {
+	mutex    sync.RWMutex
+	version  uint64
+	cleaning uint64
+	addrs    map[string]time.Time
+}
+
+const (
+	resolverBlacklistCleanupInterval = 1000
+)
+
+// Blacklist adds a blacklisted address, which expires and expireAt is reached.
+func (blacklist *ResolverBlacklist) Blacklist(addr string, expireAt time.Time) {
+	blacklist.mutex.Lock()
+	if blacklist.addrs == nil {
+		blacklist.addrs = make(map[string]time.Time)
+	}
+	blacklist.addrs[addr] = expireAt
+	blacklist.mutex.Unlock()
+}
+
+// Filter takes a slice of endpoints and the current time, and returns that
+// same slice trimmed, where all blacklisted addresses have been filtered out.
+func (blacklist *ResolverBlacklist) Filter(endpoints []Endpoint, now time.Time) []Endpoint {
+	version := atomic.AddUint64(&blacklist.version, 1)
+
+	blacklist.mutex.RLock()
+	blackListLength := len(blacklist.addrs)
+	endpointsLength := 0
+
+	if blackListLength == 0 {
+		// Fast path, most of the time the black list is expected to be empty,
+		// no need to pay the price of going through the endpoints in this case.
+		endpointsLength = len(endpoints)
+	} else {
+		for i := range endpoints {
+			expireAt, blacklisted := blacklist.addrs[endpoints[i].Addr.String()]
+
+			if !blacklisted || now.After(expireAt) {
+				endpoints[endpointsLength] = endpoints[i]
+				endpointsLength++
+			}
+		}
+	}
+
+	blacklist.mutex.RUnlock()
+
+	if blackListLength != 0 && (version%resolverBlacklistCleanupInterval) == 0 {
+		if atomic.CompareAndSwapUint64(&blacklist.cleaning, 0, 1) {
+			blacklist.cleanup(now)
+			atomic.StoreUint64(&blacklist.cleaning, 0)
+		}
+	}
+
+	return endpoints[:endpointsLength]
+}
+
+func (blacklist *ResolverBlacklist) cleanup(now time.Time) {
+	blacklist.mutex.RLock()
+
+	for addr, expireAt := range blacklist.addrs {
+		if now.After(expireAt) {
+			blacklist.mutex.RUnlock()
+			blacklist.mutex.Lock()
+
+			if expireAt := blacklist.addrs[addr]; now.After(expireAt) {
+				delete(blacklist.addrs, addr)
+			}
+
+			blacklist.mutex.Unlock()
+			blacklist.mutex.RLock()
+		}
+	}
+
+	blacklist.mutex.RUnlock()
 }

--- a/resolver.go
+++ b/resolver.go
@@ -220,6 +220,7 @@ func (rslv *Resolver) tomography() *Tomography {
 // DefaultResolver is the Resolver used by a Dialer when non has been specified.
 var DefaultResolver = &Resolver{
 	OnlyPassing: true,
+	Blacklist:   &ResolverBlacklist{},
 	Sort:        WeightedShuffleOnRTT,
 }
 

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -78,9 +78,9 @@ func testLookupService(t *testing.T, cache *ResolverCache) {
 	}
 
 	if !reflect.DeepEqual(addrs, []Endpoint{
-		{Addr: &serviceAddr{"192.168.0.1", 4242}},
-		{Addr: &serviceAddr{"192.168.0.2", 4242}},
-		{Addr: &serviceAddr{"192.168.0.3", 4242}},
+		{Addr: newServiceAddr("192.168.0.1", 4242)},
+		{Addr: newServiceAddr("192.168.0.2", 4242)},
+		{Addr: newServiceAddr("192.168.0.3", 4242)},
 	}) {
 		t.Error("bad addresses returned:", addrs)
 	}
@@ -213,9 +213,9 @@ func testLookupHost(t *testing.T, cache *ResolverCache) {
 
 func TestResolverCache(t *testing.T) {
 	list := []Endpoint{
-		{Addr: &serviceAddr{"192.168.0.1", 4242}},
-		{Addr: &serviceAddr{"192.168.0.2", 4242}},
-		{Addr: &serviceAddr{"192.168.0.3", 4242}},
+		{Addr: newServiceAddr("192.168.0.1", 4242)},
+		{Addr: newServiceAddr("192.168.0.2", 4242)},
+		{Addr: newServiceAddr("192.168.0.3", 4242)},
 	}
 
 	t.Run("ensure there are cache hits when making service lookup calls in a tight loop", func(t *testing.T) {
@@ -282,4 +282,100 @@ func TestResolverCache(t *testing.T) {
 			t.Error("bad number of cache misses:", n)
 		}
 	})
+}
+
+func TestResolverBlacklist(t *testing.T) {
+	tests := []struct {
+		scenario string
+		function func(*testing.T, *ResolverBlacklist, []Endpoint)
+	}{
+		{
+			scenario: "when no address is blacklisted no address is filtered out",
+			function: testResolverBlacklistNoFilter,
+		},
+		{
+			scenario: "blacklisted addresses are filtered out of the endpoint list",
+			function: testResolverBlacklistFilter,
+		},
+		{
+			scenario: "blacklisted addresses are cleaned up after enough calls to Filter",
+			function: testResolverBlacklistCleanup,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			blacklist := &ResolverBlacklist{}
+			endpoints := []Endpoint{
+				{ID: "A", Addr: newServiceAddr("127.0.0.1", 1000)},
+				{ID: "B", Addr: newServiceAddr("127.0.0.1", 1001)},
+				{ID: "C", Addr: newServiceAddr("127.0.0.1", 1002)},
+				{ID: "D", Addr: newServiceAddr("127.0.0.1", 1003)},
+				{ID: "E", Addr: newServiceAddr("127.0.0.1", 1004)},
+			}
+
+			test.function(t, blacklist, endpoints)
+		})
+	}
+}
+
+func testResolverBlacklistNoFilter(t *testing.T, blacklist *ResolverBlacklist, endpoints []Endpoint) {
+	now := time.Now()
+
+	list := make([]Endpoint, len(endpoints))
+	copy(list, endpoints)
+
+	if unfiltered := blacklist.Filter(list, now); !reflect.DeepEqual(unfiltered, endpoints) {
+		t.Error("bad endpoint list:")
+		t.Log("expected:", endpoints)
+		t.Log("found:   ", unfiltered)
+	}
+}
+
+func testResolverBlacklistFilter(t *testing.T, blacklist *ResolverBlacklist, endpoints []Endpoint) {
+	now := time.Now()
+
+	blacklist.Blacklist("127.0.0.1:1000", now.Add(time.Second))
+	blacklist.Blacklist("127.0.0.1:1003", now.Add(time.Millisecond))
+	blacklist.Blacklist("192.168.0.1:8080", now.Add(time.Hour))
+
+	list := make([]Endpoint, len(endpoints))
+	copy(list, endpoints)
+
+	expected := []Endpoint{
+		{ID: "B", Addr: newServiceAddr("127.0.0.1", 1001)},
+		{ID: "C", Addr: newServiceAddr("127.0.0.1", 1002)},
+		{ID: "D", Addr: newServiceAddr("127.0.0.1", 1003)},
+		{ID: "E", Addr: newServiceAddr("127.0.0.1", 1004)},
+	}
+
+	if filtered := blacklist.Filter(list, now.Add(500*time.Millisecond)); !reflect.DeepEqual(filtered, expected) {
+		t.Error("bad endpoint list:")
+		t.Log("expected:", expected)
+		t.Log("found:   ", filtered)
+	}
+}
+
+func testResolverBlacklistCleanup(t *testing.T, blacklist *ResolverBlacklist, endpoints []Endpoint) {
+	now := time.Now()
+
+	blacklist.Blacklist("127.0.0.1:1000", now.Add(time.Second))
+	blacklist.Blacklist("127.0.0.1:1003", now.Add(time.Millisecond))
+	blacklist.Blacklist("192.168.0.1:8080", now.Add(time.Hour))
+
+	for i := 0; i != (resolverBlacklistCleanupInterval + 1); i++ {
+		list := make([]Endpoint, len(endpoints))
+		copy(list, endpoints)
+		blacklist.Filter(list, now.Add(2*time.Second))
+	}
+
+	blacklist.mutex.Lock()
+
+	if !reflect.DeepEqual(blacklist.addrs, map[string]time.Time{
+		"192.168.0.1:8080": now.Add(time.Hour),
+	}) {
+		t.Error("bad blacklist state:", blacklist.addrs)
+	}
+
+	blacklist.mutex.Unlock()
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -335,9 +335,9 @@ func testResolverBlacklistNoFilter(t *testing.T, blacklist *ResolverBlacklist, e
 func testResolverBlacklistFilter(t *testing.T, blacklist *ResolverBlacklist, endpoints []Endpoint) {
 	now := time.Now()
 
-	blacklist.Blacklist("127.0.0.1:1000", now.Add(time.Second))
-	blacklist.Blacklist("127.0.0.1:1003", now.Add(time.Millisecond))
-	blacklist.Blacklist("192.168.0.1:8080", now.Add(time.Hour))
+	blacklist.Blacklist(newServiceAddr("127.0.0.1", 1000), now.Add(time.Second))
+	blacklist.Blacklist(newServiceAddr("127.0.0.1", 1003), now.Add(time.Millisecond))
+	blacklist.Blacklist(newServiceAddr("192.168.0.1", 8080), now.Add(time.Hour))
 
 	list := make([]Endpoint, len(endpoints))
 	copy(list, endpoints)
@@ -359,9 +359,9 @@ func testResolverBlacklistFilter(t *testing.T, blacklist *ResolverBlacklist, end
 func testResolverBlacklistCleanup(t *testing.T, blacklist *ResolverBlacklist, endpoints []Endpoint) {
 	now := time.Now()
 
-	blacklist.Blacklist("127.0.0.1:1000", now.Add(time.Second))
-	blacklist.Blacklist("127.0.0.1:1003", now.Add(time.Millisecond))
-	blacklist.Blacklist("192.168.0.1:8080", now.Add(time.Hour))
+	blacklist.Blacklist(newServiceAddr("127.0.0.1", 1000), now.Add(time.Second))
+	blacklist.Blacklist(newServiceAddr("127.0.0.1", 1003), now.Add(time.Millisecond))
+	blacklist.Blacklist(newServiceAddr("192.168.0.1", 8080), now.Add(time.Hour))
 
 	for i := 0; i != (resolverBlacklistCleanupInterval + 1); i++ {
 		list := make([]Endpoint, len(endpoints))


### PR DESCRIPTION
The intent of this PR is to add a mechanism for temporarily preventing addresses that are known to be unreachable from being returned by the resolver. This helps being more reactive to services going away/down instead of relying on consul to detect the issue due to failing health checks or registrator removing the services, but also helps in situations where the resolver is caching the lookups to consul, in which case it may take a couple of seconds before it is able to get the updated state.

Please take a look and let me know if something should be changed.