### PR TITLE
don't crash when balancing empty list of endpoints

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -158,6 +158,9 @@ type RoundRobin struct {
 // Balance satisfies the Balancer interface.
 func (rr *RoundRobin) Balance(name string, endpoints []Endpoint) []Endpoint {
 	n := len(endpoints)
+	if n == 0 {
+		return endpoints
+	}
 	i := int(atomic.AddUint64(&rr.offset, 1) % uint64(n))
 	return endpoints[i : i+1]
 }
@@ -174,13 +177,11 @@ type Rotator struct {
 
 // Balance satisfies the Balancer interface.
 func (rr *Rotator) Balance(name string, endpoints []Endpoint) []Endpoint {
-	n := len(endpoints)
-	i := int(atomic.AddUint64(&rr.offset, 1) % uint64(n))
-
-	if i != 0 {
-		rotate(endpoints, i)
+	if n := len(endpoints); n != 0 {
+		if i := int(atomic.AddUint64(&rr.offset, 1) % uint64(n)); i != 0 {
+			rotate(endpoints, i)
+		}
 	}
-
 	return endpoints
 }
 

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -81,6 +81,10 @@ func testBalancer(t *testing.T, balancer Balancer) {
 		value int
 	}
 
+	// Ensure that the balance doesn't crash when it's given an empty list of
+	// endpoints.
+	balancer.Balance("empty-service", nil)
+
 	base := generateTestEndpoints(endpointsCount)
 	counters := make([]counter, endpointsCount)
 	for i := range counters {


### PR DESCRIPTION
Ilya reported a bug where if a service name doesn't exist in consul the program would panic due to a division by zero, this PR addresses the issue.
