### PR TITLE
Fix path joining

### DIFF
--- a/locker_test.go
+++ b/locker_test.go
@@ -129,7 +129,7 @@ func TestLockReleased(t *testing.T) {
 func TestLockLoseSession(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	session, expire := WithSession(ctx, Session{})

--- a/store.go
+++ b/store.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"path"
 	"strconv"
 	"strings"
 
@@ -243,13 +242,30 @@ func (store *Store) client() *Client {
 }
 
 func (store *Store) path(key string) string {
-	return path.Join("/v1/kv", store.Keyspace, key)
+	return formatKVPath(store.Keyspace, key)
 }
 
 func (store *Store) clean(key string) string {
 	key = strings.TrimPrefix(key, store.Keyspace)
 	key = strings.TrimPrefix(key, "/")
 	return key
+}
+
+func formatKVPath(prefix, key string) string {
+	joined := strings.Join([]string{"/v1/kv", prefix, key}, "/")
+
+	// collapse slashes
+	out := []rune{}
+	var last rune
+	for _, runeValue := range joined {
+		if runeValue == '/' && last == '/' {
+			continue
+		}
+		out = append(out, runeValue)
+		last = runeValue
+	}
+
+	return string(out)
 }
 
 var (

--- a/store.go
+++ b/store.go
@@ -276,7 +276,7 @@ func cleanPath(p string) string {
 }
 
 func formatKVPath(prefix, key string) string {
-	joined := cleanPath("/v1/kv/"+prefix) + "/" + cleanPath(key)
+	joined := cleanPath("/v1/kv") + "/" + cleanPath(prefix) + "/" + cleanPath(key)
 
 	// collapse slashes
 	out := []rune{}

--- a/store_test.go
+++ b/store_test.go
@@ -307,6 +307,9 @@ func TestFormatKVPath(t *testing.T) {
 	assertKVP("/v1/kv/prefix/", "prefix/", "/")
 	assertKVP("/v1/kv/prefix/", "/prefix/", "/")
 
-	// don't do .. and . collapse
-	assertKVP("/v1/kv/prefix/key/../whatever/.", "prefix", "/key/../whatever/.")
+	// collapse but don't allow going below the prefix
+	assertKVP("/v1/kv/prefix/whatever", "prefix", "../whatever")
+	assertKVP("/v1/kv/prefix/whatever/", "prefix", "../whatever/")
+	assertKVP("/v1/kv/prefix/whatever/", "prefix", "../whatever/.")
+	assertKVP("/v1/kv/prefix/", "prefix", "../whatever/..")
 }

--- a/store_test.go
+++ b/store_test.go
@@ -312,4 +312,7 @@ func TestFormatKVPath(t *testing.T) {
 	assertKVP("/v1/kv/prefix/whatever/", "prefix", "../whatever/")
 	assertKVP("/v1/kv/prefix/whatever/", "prefix", "../whatever/.")
 	assertKVP("/v1/kv/prefix/", "prefix", "../whatever/..")
+
+	// or the prefix dropping below the /v1/kv/ root
+	assertKVP("/v1/kv/prefix/", "../prefix", "")
 }


### PR DESCRIPTION
This patch fixes path joining to handle trailing slashes properly. An example of where the existing behavior breaks is issuing a delete on a subdirectory. It also bumps a context deadline timeout a bit to reduce the flakiness of that test.