### PR TITLE
better concurrency on resolver cache

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -367,6 +367,10 @@ func (cache *ResolverCache) compareAndSwap(old *resolverCache, new *resolverCach
 }
 
 func (cache *ResolverCache) update(name string, entry *resolverEntry) {
+	if b := cache.Balancer; b != nil {
+		entry.res = b.Balance(name, entry.res)
+	}
+
 	for {
 		oldCache := cache.load()
 		newCache := oldCache.copy()

--- a/resolver.go
+++ b/resolver.go
@@ -470,12 +470,6 @@ type resolverEntry struct {
 	// Lock used to ensure that only a single goroutine takes care of refreshing
 	// the cache entry before it expires.
 	lock uint32
-
-	// Atomically incremented each time the entry is used. The cleanup process
-	// uses lastVersion to identify which entries need to be cleared out of the
-	// cache (if version == lastVersion, the entry wasn't used).
-	version     uint32
-	lastVersion uint32
 }
 
 func (entry *resolverEntry) tryLock() bool {


### PR DESCRIPTION
Follow up of #28 

This is a similar change on the resolver cache to get rid of the locks on the critical path, here are the benchmarks comparing master and this branch:
```
goos: darwin
goarch: amd64
pkg: github.com/segmentio/consul-go
BenchmarkResolverCache       	 5000000	       249 ns/op	     288 B/op	       1 allocs/op
BenchmarkResolverCache-8     	10000000	       169 ns/op	     288 B/op	       1 allocs/op
BenchmarkResolverCache-32    	10000000	       206 ns/op	     288 B/op	       1 allocs/op
PASS
ok  	github.com/segmentio/consul-go	5.623s
```
```
goos: darwin
goarch: amd64
pkg: github.com/segmentio/consul-go
BenchmarkResolverCache       10000000       199 ns/op     288 B/op       1 allocs/op
BenchmarkResolverCache-8     20000000       126 ns/op     288 B/op       1 allocs/op
BenchmarkResolverCache-32    10000000       130 ns/op     288 B/op       1 allocs/op
PASS
ok  github.com/segmentio/consul-go6.306s
```
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkResolverCache        249           199           -20.08%
BenchmarkResolverCache-8      169           126           -25.44%
BenchmarkResolverCache-32     206           130           -36.89%

benchmark                     old allocs     new allocs     delta
BenchmarkResolverCache        1              1              +0.00%
BenchmarkResolverCache-8      1              1              +0.00%
BenchmarkResolverCache-32     1              1              +0.00%

benchmark                     old bytes     new bytes     delta
BenchmarkResolverCache        288           288           +0.00%
BenchmarkResolverCache-8      288           288           +0.00%
BenchmarkResolverCache-32     288           288           +0.00%
```
The nice thing we see here is that besides the fact that the implementation is faster, the code is performing better as concurrency increases, which was the goal of this change.

From looking at a CPU profile of the benchmark he bottleneck now is clearly the dynamic memory allocation that occurs to return the list of endpoints... but we can't get rid of it without revisiting the design, I'll leave this for future improvements.