### PR TITLE
fix fromSeconds

### DIFF
--- a/time.go
+++ b/time.go
@@ -15,8 +15,8 @@ func seconds(d time.Duration) string {
 func fromSeconds(v string) time.Duration {
 	d, err := time.ParseDuration(v)
 	if err != nil {
-		i, _ := strconv.ParseInt(v, 10, 64)
-		d = time.Duration(i)
+		f, _ := strconv.ParseFloat(v, 64)
+		d = time.Duration(f)
 	}
 	return d
 }

--- a/time_test.go
+++ b/time_test.go
@@ -22,4 +22,8 @@ func TestFromSeconds(t *testing.T) {
 	if d := fromSeconds("15000000000"); d != 15*time.Second {
 		t.Error("duration should be 15 seconds:", d.Seconds())
 	}
+
+	if d := fromSeconds("1.5e+10"); d != 15*time.Second {
+		t.Error("duration should be 15 seconds:", d.Seconds())
+	}
 }


### PR DESCRIPTION
This PR fixe the fromSeconds parsing.
Consul can give a lock delay using 3 different forms:
- 15s
- 15000000000
- 1.5e+10

strconv.ParseInt have been replaced by strconv.ParseFloat in order to handle the third case.