### PR TITLE
resolver use stale queries

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -145,7 +145,7 @@ func (rslv *Resolver) lookupService(ctx context.Context, name string) (list []En
 	query := make(Query, 0, 1+len(rslv.NodeMeta)+len(rslv.ServiceTags))
 
 	if rslv.OnlyPassing {
-		query = append(query, Param{Name: "passing"})
+		query = append(query, Param{Name: "passing"}, Param{Name: "stale"})
 	}
 
 	for key, value := range rslv.NodeMeta {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -39,6 +39,7 @@ func testLookupService(t *testing.T, cache *ResolverCache) {
 		foundQuery := req.URL.Query()
 		expectQuery := url.Values{
 			"passing":   {""},
+			"stale":     {""},
 			"dc":        {"dc1"},
 			"tag":       {"A", "B", "C"},
 			"node-meta": {"answer:42"},
@@ -164,6 +165,7 @@ func testLookupHost(t *testing.T, cache *ResolverCache) {
 		foundQuery := req.URL.Query()
 		expectQuery := url.Values{
 			"passing":   {""},
+			"stale":     {""},
 			"dc":        {"dc1"},
 			"tag":       {"A", "B", "C"},
 			"node-meta": {"answer:42"},


### PR DESCRIPTION
There's no need to enforce strong consistency during service name resolution, those things come and go asynchronously, and it'll save tons of traffic going to the consul server.