### PR TITLE
Add zero-allocation LookupServiceInto to resolver

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -373,6 +373,32 @@ func BenchmarkResolverCache(b *testing.B) {
 	})
 }
 
+func BenchmarkResolverCacheInto(b *testing.B) {
+	list := []Endpoint{
+		{Addr: newServiceAddr("192.168.0.1", 4242)},
+		{Addr: newServiceAddr("192.168.0.2", 4242)},
+		{Addr: newServiceAddr("192.168.0.3", 4242)},
+	}
+
+	cache := &ResolverCache{
+		CacheTimeout: 10 * time.Millisecond,
+	}
+
+	lookup := func(ctx context.Context, name string) (addrs []Endpoint, err error) {
+		return list, nil
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		ctx := context.Background()
+
+		res := make([]Endpoint, 10)
+
+		for pb.Next() {
+			cache.LookupServiceInto(ctx, "", res, lookup)
+		}
+	})
+}
+
 func TestResolverBlacklist(t *testing.T) {
 	tests := []struct {
 		scenario string


### PR DESCRIPTION
We call `LookupService` with extremely high frequency (~2000/s per process). The time spent allocating during a `LookupService` call end up being roughly 25% of our execution time.

This adds a `LookupServiceInto` variant that will fill the given slice with the results if it is large enough, expanding it otherwise.

Benchmarking this shows roughly a 5x speedup compared to the allocating variant.
```
$> go test -bench=BenchmarkResolverCache -benchmem
goos: darwin
goarch: amd64
pkg: github.com/segmentio/consul-go
BenchmarkResolverCache-8       	20000000	        71.3 ns/op	     288 B/op	       1 allocs/op
BenchmarkResolverCacheInto-8   	100000000	        12.9 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/segmentio/consul-go	5.128s
```
vs on master:
```
$> go test -bench=BenchmarkResolverCache -benchmem
goos: darwin
goarch: amd64
pkg: github.com/segmentio/consul-go
BenchmarkResolverCache-8   	20000000	        70.5 ns/op	     288 B/op	       1 allocs/op
PASS
ok  	github.com/segmentio/consul-go	3.809s
```