### PR TITLE
Allow compare-and-swap against nonexistent value

### DIFF
--- a/store.go
+++ b/store.go
@@ -185,7 +185,7 @@ func (store *Store) Write(ctx context.Context, key string, value io.ReadCloser, 
 		}
 	}
 
-	if index > 0 {
+	if index >= 0 {
 		query = append(query, Param{
 			Name:  "cas",
 			Value: strconv.FormatInt(index, 10),


### PR DESCRIPTION
Consul allows you to pass `0` as the modified index during a compare-and-swap operation, which signifies that the value must not exist. We were leaving off the `cas` param if the index was zero.

The biggest risk here is if anyone is using `0` as the "don't cas" signal value instead of `-1`. I did a quick scan through our repos and didn't find any of these cases, but it certainly wasn't an exhaustive search.