### PR TITLE
fix invalid content length for client calls with json bodies:

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -123,7 +122,7 @@ func (c *Client) do(ctx context.Context, method string, path string, query Query
 		if b, err = json.Marshal(send); err != nil {
 			return
 		}
-		req = ioutil.NopCloser(bytes.NewReader(b))
+		req = &buffer{bytes.NewReader(b)}
 	}
 
 	header, res, err = c.call(ctx, method, path, query, req)
@@ -285,7 +284,7 @@ func (q Query) Values() url.Values {
 }
 
 type buffer struct {
-	bytes.Buffer
+	*bytes.Reader
 }
 
 func (*buffer) Close() error { return nil }

--- a/client_test.go
+++ b/client_test.go
@@ -45,7 +45,7 @@ func TestClient(t *testing.T) {
 			path:   "/hello/world",
 			query:  nil,
 			recv:   map[string]string{},
-			send:   map[string]string{},
+			send:   map[string]string{"body": "test"},
 		},
 		{
 			method: "DELETE",
@@ -75,6 +75,10 @@ func TestClient(t *testing.T) {
 
 				if !reflect.DeepEqual(send, test.send) {
 					t.Error(send)
+				}
+
+				if send != nil && req.ContentLength < 0 {
+					t.Error("invalid content length")
 				}
 
 				json.NewEncoder(res).Encode(test.recv)


### PR DESCRIPTION
Content length is computed by first checking if the type of the request body implements a Len() function.  The original implementation wrapped the request body in an `io.NopCloser`, which does not implement that interface.

Because of this, content length was set to -1, which had the side effect of telling consul to ignore the body of the request.  I ran into this when creating sessions, since consul was ignoring all properties of the session (Name, TTL, etc).