### PR TITLE
Add support for exponential backoff for watchers

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -130,7 +130,7 @@ func (w *Watcher) watching(ctx context.Context, key string, handler WatcherFunc,
 
 			// exponential backoff to prevent tight-loop when the caller has not
 			// cancelled the context
-			time.Sleep(time.Duration(attempt>>1) * time.Millisecond)
+			time.Sleep(time.Duration(attempt<<1) * time.Millisecond)
 			continue
 		}
 

--- a/watcher.go
+++ b/watcher.go
@@ -119,7 +119,6 @@ func (w *Watcher) watching(ctx context.Context, key string, handler WatcherFunc,
 		// 1) prevent tight-loop if the handler isn't cancelling the context
 		// 2) provides back-pressure when consul is down
 		// 3) gives the handler visibility to all errors
-		// prevents a tight loop on continuous errors while also notiying the caller.
 		if err != nil {
 			attempt++
 			if attempt <= w.MaxAttempts {

--- a/watcher.go
+++ b/watcher.go
@@ -130,7 +130,12 @@ func (w *Watcher) watching(ctx context.Context, key string, handler WatcherFunc,
 
 			// exponential backoff to prevent tight-loop when the caller has not
 			// cancelled the context
-			time.Sleep(time.Duration(attempt<<1) * time.Millisecond)
+			timer := time.NewTimer(time.Duration(attempt<<1) * time.Millisecond)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+			}
+			timer.Stop()
 			continue
 		}
 

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -89,7 +89,7 @@ func TestWatchTimeoutMaxAttempts(t *testing.T) {
 	c := &Client{
 		Transport: ts,
 	}
-	w := &Watcher{Client: c, MaxAttempts: 10}
+	w := &Watcher{Client: c, MaxAttempts: 2, MaxBackoff: 10 * time.Millisecond}
 	go w.Watch(ctx, "test3/key", func(d []KeyData, err error) {
 		// We should only see this function 2x: first for initialization,
 		// then the timeout.  we never trigger the watch and all the errors
@@ -142,7 +142,7 @@ func TestWatchPrefixNonExistant(t *testing.T) {
 }
 
 func TestWatchMaxBackoff(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //, 3*time.Second)
 	err := DefaultClient.Put(ctx, "/v1/kv/test5/key", nil, "blah", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +153,7 @@ func TestWatchMaxBackoff(t *testing.T) {
 		Transport: &mockTransport{500, nil, nil},
 	}
 	maxAttempts := 2
-	initialBackoff := 1 * time.Hour // max backoff will constrain this
+	initialBackoff := 1 * time.Hour
 	maxBackoff := 10 * time.Millisecond
 	w := &Watcher{Client: c, MaxAttempts: maxAttempts, InitialBackoff: initialBackoff, MaxBackoff: maxBackoff}
 	start := time.Now()

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -118,7 +118,8 @@ func TestWatchPrefixNonExistant(t *testing.T) {
 	ch := make(chan []KeyData, 1)
 	skipFirst := true
 
-	go WatchPrefix(ctx, "test4/key", func(d []KeyData, err error) {
+	w := &Watcher{MaxBackoff: 10 * time.Millisecond}
+	go w.WatchPrefix(ctx, "test4/key", func(d []KeyData, err error) {
 		if skipFirst {
 			skipFirst = false
 			return
@@ -185,7 +186,7 @@ func TestWatchErrorMaxAttempts(t *testing.T) {
 	c := &Client{
 		Transport: &mockTransport{500, nil, nil},
 	}
-	w := &Watcher{Client: c, MaxAttempts: 10}
+	w := &Watcher{Client: c, MaxAttempts: 10, MaxBackoff: 1 * time.Second}
 	go w.Watch(ctx, "test6/key", func(d []KeyData, err error) {
 		if err == nil {
 			t.Error("Expected error but got nil")


### PR DESCRIPTION
When watch handlers do not explicitly cancel context, there was an edge-case where this would result in the watcher spin-looping forever despite the maximum attempt threshold being met. This adds logic to do exponential backoff after the watcher has reached a maximum number of attempts while at the same time preserving the existing behavior of only bailing out of the watcher when the context is explicitly cancelled. This both simplifies the watcher code and prevents unintentional abuse when Consul is down or having issues.