### PR TITLE
use consul agent cache

### DIFF
--- a/listener_test.go
+++ b/listener_test.go
@@ -14,7 +14,7 @@ func TestListener(t *testing.T) {
 		CheckHTTP:                           "/",
 		CheckInterval:                       10 * time.Second,
 		CheckDeregisterCriticalServiceAfter: 90 * time.Second,
-	}).ListenContext(context.Background(), "tcp", ":0")
+	}).ListenContext(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Error(err)
 		return

--- a/resolver.go
+++ b/resolver.go
@@ -150,8 +150,13 @@ func (rslv *Resolver) lookupService(ctx context.Context, name string) (list []En
 
 	query := make(Query, 0, 1+len(rslv.NodeMeta)+len(rslv.ServiceTags))
 
+	query = append(query,
+		Param{Name: "stale", Value: "true"},
+		Param{Name: "cached", Value: "true"},
+	)
+
 	if rslv.OnlyPassing {
-		query = append(query, Param{Name: "passing"}, Param{Name: "stale"})
+		query = append(query, Param{Name: "passing", Value: "true"})
 	}
 
 	for key, value := range rslv.NodeMeta {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -37,8 +37,9 @@ func testLookupService(t *testing.T, cache *ResolverCache) {
 
 		foundQuery := req.URL.Query()
 		expectQuery := url.Values{
-			"passing":   {""},
-			"stale":     {""},
+			"passing":   {"true"},
+			"stale":     {"true"},
+			"cached":    {"true"},
 			"dc":        {"dc1"},
 			"tag":       {"A", "B", "C"},
 			"node-meta": {"answer:42"},
@@ -93,7 +94,7 @@ func testLookupServiceByName(t *testing.T, cache *ResolverCache) {
 		ServiceID:   "1234",
 	}
 
-	l, err := lstn.Listen("tcp", ":0")
+	l, err := lstn.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +126,7 @@ func testLookupServiceByID(t *testing.T, cache *ResolverCache) {
 		ServiceID:   "1234",
 	}
 
-	l, err := lstn.Listen("tcp", ":0")
+	l, err := lstn.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,8 +164,9 @@ func testLookupHost(t *testing.T, cache *ResolverCache) {
 
 		foundQuery := req.URL.Query()
 		expectQuery := url.Values{
-			"passing":   {""},
-			"stale":     {""},
+			"passing":   {"true"},
+			"stale":     {"true"},
+			"cached":    {"true"},
 			"dc":        {"dc1"},
 			"tag":       {"A", "B", "C"},
 			"node-meta": {"answer:42"},
@@ -220,7 +222,7 @@ func testLookupServiceWithBalancer(t *testing.T) {
 		ServiceTags: []string{"us-west-2b"},
 	}
 
-	l1, err := lstn.Listen("tcp", ":0")
+	l1, err := lstn.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +231,7 @@ func testLookupServiceWithBalancer(t *testing.T) {
 	lstn.ServiceID = "5678"
 	lstn.ServiceTags = []string{"us-west-2a"}
 
-	l2, err := lstn.Listen("tcp", ":0")
+	l2, err := lstn.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fix the service resolver abstraction to use the consul agent cache instead of forcing the requests to go to the servers.