### PR TITLE
limit the size of generated session names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/segmentio/consul-go

--- a/locker.go
+++ b/locker.go
@@ -196,7 +196,7 @@ func TryLockOne(ctx context.Context, keys ...string) (context.Context, context.C
 func makeSessionName(prefix string, args ...string) string {
 	// Arbitrary max value to limit the max size of session names we generate.
 	if len(args) > 4 {
-		return prefix + fmt.Sprint("[%s... %d keys]", args[0], len(args))
+		return prefix + fmt.Sprintf("[%s... %d keys]", args[0], len(args))
 	} else {
 		return prefix + fmt.Sprint(args)
 	}


### PR DESCRIPTION
This PR is a follow up to the investigation I did on the session renewal in consul which showed that we are creating sessions with very long names, and the name are exchanged over and over between the consul agents and the servers, for example:
```
[{"ID":"09d99bd9-ccc4-6712-2749-7e2c787aaab8","Name":"try-lock: [centrifuge/destinations/databases/jobdb/centrifuge-jobdb-destinations-manille/lock centrifuge/destinations/databases/jobdb/centrifuge-jobdb-destinations-holofrench/lock centrifuge/destinations/databases/jobdb/centrifuge-jobdb-destinations-slumarsh/lock ...
```
