### PR TITLE
efficient kv store reads

### DIFF
--- a/store.go
+++ b/store.go
@@ -120,7 +120,7 @@ func (store *Store) WalkData(ctx context.Context, prefix string, walk func(data 
 	var keyData KeyData
 
 	if _, err = dec.Token(); err != nil { // discard '[' to iterate the response
-		err = fmt.Errorf("error attempting to read opening '[' from consul response:", err)
+		err = fmt.Errorf("error attempting to read opening '[' from consul response: %v", err)
 		return
 	}
 

--- a/store.go
+++ b/store.go
@@ -132,6 +132,7 @@ func (store *Store) WalkData(ctx context.Context, prefix string, walk func(data 
 		if err = walk(keyData); err != nil {
 			return
 		}
+		keyData = KeyData{}
 	}
 
 	err = result.Close()


### PR DESCRIPTION
This PR modifies the consul KV store client to support stale reads (read operations that are served by any server, not just the leader).

I also modified the `consul.(*Store).WalkData` implementation to be iterative instead of loading the whole data set in memory (I'm planning to use this in centrifuge/integrations-consumer to reduce the number of GET requests we make).